### PR TITLE
Refactor/12 paper

### DIFF
--- a/app/library/[id]/page.tsx
+++ b/app/library/[id]/page.tsx
@@ -30,24 +30,28 @@ export async function generateMetadata({ params }: PageProps) {
 
     if (!paperDetail) {
       return {
-        title: '논문을 찾을 수 없습니다 | Curify',
+        title: '논문을 찾을 수 없습니다 | Curatify',
         description: '요청하신 논문을 찾을 수 없습니다.',
       };
     }
 
+    // content 배열에서 첫 번째 블록의 content를 사용하여 설명 생성
+    const firstContent = paperDetail.content[0]?.content || '';
+    const description = firstContent.substring(0, 160) + (firstContent.length > 160 ? '...' : '');
+
     return {
-      title: `${paperDetail.title} | Curify`,
-      description: paperDetail.content.substring(0, 160) + '...',
+      title: `${paperDetail.title} | Curatify`,
+      description,
       openGraph: {
         title: paperDetail.title,
-        description: paperDetail.content.substring(0, 160) + '...',
+        description,
         type: 'article',
         authors: paperDetail.authors,
       },
     };
-  } catch (error) {
+  } catch {
     return {
-      title: '논문 상세 | Curify',
+      title: '논문 상세 | Curatify',
       description: '논문 상세 정보를 불러오는 중 오류가 발생했습니다.',
     };
   }
@@ -124,11 +128,15 @@ export default async function PaperDetailPage({ params }: PageProps) {
 
         {/* 메인 콘텐츠 */}
         <Card className="mb-6">
-          <CardContent>
+          <CardContent className="pt-6">
             <div className="prose prose-lg max-w-none">
-              <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
-                {paperDetail.content}
-              </ReactMarkdown>
+              {paperDetail.content.map((contentBlock) => (
+                <div key={contentBlock.id} className="mb-12">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
+                    {contentBlock.content}
+                  </ReactMarkdown>
+                </div>
+              ))}
             </div>
           </CardContent>
         </Card>

--- a/app/library/[id]/page.tsx
+++ b/app/library/[id]/page.tsx
@@ -14,6 +14,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { ExternalLink, Calendar, Users, FileText } from 'lucide-react';
 import BackButton from '@/app/library/[id]/BackButton';
+import TableOfContents from '@/components/library/TableOfContents';
 
 interface PageProps {
   params: {
@@ -126,20 +127,30 @@ export default async function PaperDetailPage({ params }: PageProps) {
           )}
         </div>
 
-        {/* 메인 콘텐츠 */}
-        <Card className="mb-6">
-          <CardContent className="pt-6">
-            <div className="prose prose-lg max-w-none">
-              {paperDetail.content.map((contentBlock) => (
-                <div key={contentBlock.id} className="mb-12">
-                  <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
-                    {contentBlock.content}
-                  </ReactMarkdown>
+        {/* 목차와 메인 콘텐츠 그리드 레이아웃 */}
+        <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
+          {/* 메인 콘텐츠 */}
+          <div className="lg:col-span-3">
+            <Card className="mb-6">
+              <CardContent className="pt-6">
+                <div className="prose prose-lg max-w-none">
+                  {paperDetail.content.map((contentBlock) => (
+                    <div key={contentBlock.id} id={`section-${contentBlock.id}`} className="mb-12">
+                      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
+                        {contentBlock.content}
+                      </ReactMarkdown>
+                    </div>
+                  ))}
                 </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* 목차 사이드바 */}
+          <div className="lg:col-span-1">
+            <TableOfContents content={paperDetail.content} />
+          </div>
+        </div>
 
         {/* 추가 정보 */}
         <Card>

--- a/components/library/TableOfContents.tsx
+++ b/components/library/TableOfContents.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import React from 'react';
+import ScrollSpy from 'react-scrollspy-navigation';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { List } from 'lucide-react';
+
+interface PaperContentBlock {
+  id: number;
+  title: string;
+  content: string;
+  order: number;
+}
+
+interface TableOfContentsProps {
+  content: PaperContentBlock[];
+}
+
+/**
+ * 논문 목차 컴포넌트
+ * react-scrollspy-navigation을 사용하여 스크롤 스파이 기능 제공
+ * 스티키 포지션으로 스크롤 시에도 고정됨
+ */
+export default function TableOfContents({ content }: TableOfContentsProps) {
+  // 콘텐츠 블록이 2개 이상일 때만 목차 표시
+  if (content.length <= 1) {
+    return null;
+  }
+  console.log(content);
+  return (
+    <div className="sticky top-4 z-10 mb-6">
+      <Card className="max-h-[calc(100vh-2rem)] overflow-y-auto">
+        <CardHeader className="sticky top-0 bg-white border-b z-10">
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <List className="w-5 h-5" />
+            목차
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-4">
+          <ScrollSpy activeClass="text-blue-600 font-semibold" offsetTop={120}>
+            <nav>
+              <ul className="space-y-2">
+                {content.map((contentBlock) => (
+                  <li key={contentBlock.id}>
+                    <a
+                      href={`#section-${contentBlock.id}`}
+                      className="text-gray-600 hover:text-blue-600 transition-colors duration-200 block py-2 px-3 rounded-md hover:bg-gray-50"
+                    >
+                      {contentBlock.title}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          </ScrollSpy>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/docker/init.sql
+++ b/docker/init.sql
@@ -94,29 +94,29 @@ CREATE TABLE IF NOT EXISTS cs_paper_category_relations (
 -- Paper Content 테이블 생성 (논문 상세 내용)
 CREATE TABLE IF NOT EXISTS paper_content (
     id INT AUTO_INCREMENT PRIMARY KEY,
-    title VARCHAR(500) NOT NULL,
-    authors TEXT,
+    content_title VARCHAR(500) NOT NULL,
     content LONGTEXT NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `order` INT NOT NULL,
     paper_id INT NOT NULL,
     FOREIGN KEY (paper_id) REFERENCES papers(id) ON DELETE CASCADE,
     INDEX idx_paper_id (paper_id),
     INDEX idx_created_at (created_at),
-    UNIQUE KEY unique_paper_content (paper_id)
+    UNIQUE KEY unique_paper_content (paper_id, `order`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- User Library 테이블 생성 (사용자 논문 라이브러리)
 CREATE TABLE IF NOT EXISTS user_library (
     id INT AUTO_INCREMENT PRIMARY KEY,
     user_id INT NOT NULL,
-    paper_content_id INT NOT NULL,
+    paper_id INT NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-    FOREIGN KEY (paper_content_id) REFERENCES paper_content(id) ON DELETE CASCADE,
+    FOREIGN KEY (paper_id) REFERENCES papers(id) ON DELETE CASCADE,
     INDEX idx_user_id (user_id),
-    INDEX idx_paper_content_id (paper_content_id),
+    INDEX idx_paper_id (paper_id),
     INDEX idx_created_at (created_at),
-    UNIQUE KEY unique_user_paper (user_id, paper_content_id)
+    UNIQUE KEY unique_user_paper (user_id, paper_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- User Interests 테이블 생성 (사용자 관심사)

--- a/docker/init.sql
+++ b/docker/init.sql
@@ -54,11 +54,10 @@ CREATE TABLE IF NOT EXISTS rss_feeds (
     INDEX idx_created_at (created_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
--- CS Papers 테이블 생성
-CREATE TABLE IF NOT EXISTS cs_papers (
+-- Papers 테이블 생성
+CREATE TABLE IF NOT EXISTS papers (
     id INT AUTO_INCREMENT PRIMARY KEY,
     title VARCHAR(500) NOT NULL,
-    all_categories VARCHAR(200),
     authors TEXT,
     update_date TIMESTAMP NULL,
     url VARCHAR(500),
@@ -66,9 +65,30 @@ CREATE TABLE IF NOT EXISTS cs_papers (
     summary TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    INDEX idx_categories (all_categories),
     INDEX idx_update_date (update_date),
     INDEX idx_created_at (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Paper Categories 테이블 생성
+CREATE TABLE IF NOT EXISTS cs_paper_categories (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) UNIQUE NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_category_name (name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Paper-Category 관계 테이블 생성 (N:M 관계)
+CREATE TABLE IF NOT EXISTS cs_paper_category_relations (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    paper_id INT NOT NULL,
+    category_id INT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (paper_id) REFERENCES papers(id) ON DELETE CASCADE,
+    FOREIGN KEY (category_id) REFERENCES cs_paper_categories(id) ON DELETE CASCADE,
+    UNIQUE KEY unique_paper_category (paper_id, category_id),
+    INDEX idx_paper_id (paper_id),
+    INDEX idx_category_id (category_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Paper Content 테이블 생성 (논문 상세 내용)
@@ -79,7 +99,7 @@ CREATE TABLE IF NOT EXISTS paper_content (
     content LONGTEXT NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     paper_id INT NOT NULL,
-    FOREIGN KEY (paper_id) REFERENCES cs_papers(id) ON DELETE CASCADE,
+    FOREIGN KEY (paper_id) REFERENCES papers(id) ON DELETE CASCADE,
     INDEX idx_paper_id (paper_id),
     INDEX idx_created_at (created_at),
     UNIQUE KEY unique_paper_content (paper_id)

--- a/docker/seed-data.sql
+++ b/docker/seed-data.sql
@@ -46,334 +46,42 @@ INSERT INTO cs_paper_category_relations (paper_id, category_id) VALUES
 (5, 3); -- YOLO - cs.CV
 
 -- Paper Content 예시 데이터
-INSERT INTO paper_content (title, authors, content, paper_id) VALUES
-('Attention Is All You Need - 상세 내용', 'Ashish Vaswani, Noam Shazeer, Niki Parmar, Jakob Uszkoreit, Llion Jones, Aidan N. Gomez, Lukasz Kaiser, Illia Polosukhin', '# Transformer 아키텍처 상세 분석
-
-## 개요
-이 논문은 **Transformer** 아키텍처의 상세한 구현 방법과 실험 결과를 다룹니다.
-
-## 핵심 구성 요소
-
-### 1. Multi-Head Attention
-Multi-head attention 메커니즘은 다음과 같은 특징을 가집니다:
-
-- **병렬 처리**: 여러 attention head가 동시에 작동
-- **다양한 표현 학습**: 각 head가 서로 다른 관점에서 학습
-- **확장성**: head 수를 조절하여 모델 크기 조정 가능
-
-### 2. Positional Encoding
-RNN과 달리 Transformer는 위치 정보를 명시적으로 주입해야 합니다:
-
-```python
-PE(pos, 2i) = sin(pos / 10000^(2i/d_model))
-PE(pos, 2i+1) = cos(pos / 10000^(2i/d_model))
-```
-
-### 3. Encoder-Decoder 구조
-<img src="https://miro.medium.com/max/1400/1*BHzGVskWGS_3jEcYYi6miQ.png" alt="Transformer Architecture" width="600" style="display: block; margin: 20px auto; border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.1);">
-
-## 실험 결과
-
-### 번역 성능
-- **WMT 2014 English-to-German**: 28.4 BLEU 점수
-- **WMT 2014 English-to-French**: 41.8 BLEU 점수
-
-### 학습 효율성
-- **훈련 시간**: 기존 모델 대비 1/4 단축
-- **병렬화**: GPU 활용도 대폭 향상
-
-## 영향과 의의
-이 논문은 NLP 분야에 **혁명적인 변화**를 가져왔으며, 현재 대부분의 최신 언어 모델의 기반이 되고 있습니다.', 1),
-
-('BERT: Pre-training of Deep Bidirectional Transformers - 상세 내용', 'Jacob Devlin, Ming-Wei Chang, Kenton Lee, Kristina Toutanova', '# BERT: 양방향 Transformer 기반 언어 모델
-
-## 모델 아키텍처
-
-### 사전 학습 태스크
-
-#### 1. Masked Language Model (MLM)
-- **목적**: 문맥을 고려한 단어 예측
-- **방법**: 입력의 15% 토큰을 [MASK]로 대체하여 예측
-
-#### 2. Next Sentence Prediction (NSP)
-- **목적**: 문장 간 관계 학습
-- **방법**: 두 문장이 연속인지 판단하는 이진 분류
-
-<img src="https://miro.medium.com/max/1400/1*SutAQhVWrD3QwqJhVnqQjg.png" alt="BERT Pre-training Tasks" width="500" style="display: block; margin: 20px auto; border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.1);">
-
-## Fine-tuning 과정
-
-### 다양한 태스크 적용
-BERT는 다음과 같은 태스크에 fine-tuning이 가능합니다:
-
-1. **문장 분류** (Sentiment Analysis)
-2. **개체명 인식** (NER)
-3. **질의응답** (QA)
-4. **문장 유사도** (Sentence Similarity)
-
-### GLUE 벤치마크 결과
-| 태스크 | 성능 | 순위 |
-|--------|------|------|
-| CoLA | 60.5 | 1st |
-| SST-2 | 93.5 | 1st |
-| MRPC | 88.9 | 1st |
-| STS-B | 87.1 | 1st |
-
-## 기술적 특징
-
-### 양방향 컨텍스트
-- **양방향**: 좌우 문맥을 모두 고려
-- **깊은 표현**: 12-24층의 Transformer 레이어
-- **대규모 데이터**: BooksCorpus + Wikipedia
-
-### 계산 복잡도
-- **Base 모델**: 110M 파라미터
-- **Large 모델**: 340M 파라미터
-- **훈련 시간**: 4일 (16 TPU)', 2),
-
-('ResNet: Deep Residual Learning - 상세 내용', 'Kaiming He, Xiangyu Zhang, Shaoqing Ren, Jian Sun', '# ResNet: 깊은 신경망 학습의 혁신
-
-## 문제 정의
-
-### 기존 문제점
-깊은 신경망에서 발생하는 문제들:
-
-- **Vanishing Gradient**: 그래디언트 소실
-- **Degradation**: 깊이가 깊어질수록 성능 저하
-- **학습 어려움**: 20층 이상에서 학습 불안정
-
-## 해결 방법: Residual Learning
-
-### 핵심 아이디어
-**Skip Connection**을 통한 residual learning:
-
-```
-F(x) = H(x) - x
-H(x) = F(x) + x
-```
-
-<img src="https://miro.medium.com/max/1400/1*D0F3UItQ2l5Q0Ak-tjEdJg.png" alt="ResNet Block" width="400" style="display: block; margin: 20px auto; border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.1);">
-
-### Residual Block 구조
-```python
-class ResidualBlock(nn.Module):
-    def __init__(self, in_channels, out_channels):
-        super().__init__()
-        self.conv1 = nn.Conv2d(in_channels, out_channels, 3, padding=1)
-        self.conv2 = nn.Conv2d(out_channels, out_channels, 3, padding=1)
-        self.relu = nn.ReLU()
-        
-    def forward(self, x):
-        residual = x
-        out = self.relu(self.conv1(x))
-        out = self.conv2(out)
-        out += residual  # Skip connection
-        return self.relu(out)
-```
-
-## 실험 결과
-
-### ImageNet 성능
-| 모델 | 깊이 | Top-5 에러율 |
-|------|------|---------------|
-| ResNet-50 | 50층 | 6.7% |
-| ResNet-101 | 101층 | 6.0% |
-| ResNet-152 | 152층 | **5.7%** |
-
-### 학습 안정성
-- **수렴 속도**: 기존 모델 대비 2배 빠름
-- **그래디언트 흐름**: 안정적인 역전파
-- **깊이 확장**: 1000층 이상까지 확장 가능
-
-## 영향과 의의
-
-### 컴퓨터 비전 분야
-- **표준 아키텍처**: 대부분의 CNN 기반 모델이 채택
-- **성능 향상**: ImageNet 정확도 대폭 개선
-- **학습 방법론**: 깊은 신경망 학습의 새로운 패러다임
-
-### 후속 연구
-- **DenseNet**: 모든 레이어 연결
-- **Highway Networks**: 게이팅 메커니즘 도입
-- **ResNeXt**: 그룹 컨볼루션 적용', 3),
-
-('Generative Adversarial Networks - 상세 내용', 'Ian J. Goodfellow, Jean Pouget-Abadie, Mehdi Mirza, Bing Xu, David Warde-Farley, Sherjil Ozair, Aaron Courville, Yoshua Bengio', '# GAN: 생성적 적대 신경망
-
-## 기본 개념
-
-### 게임 이론적 접근
-GAN은 **minimax 게임**으로 모델링됩니다:
-
-```
-min_G max_D V(D,G) = E_x[log D(x)] + E_z[log(1-D(G(z)))]
-```
-
-### 두 네트워크의 역할
-
-#### Generator (G)
-- **목적**: 실제 데이터와 구분할 수 없는 가짜 데이터 생성
-- **입력**: 랜덤 노이즈 z
-- **출력**: 생성된 이미지 G(z)
-
-#### Discriminator (D)
-- **목적**: 실제 데이터와 가짜 데이터를 구분
-- **입력**: 실제 이미지 x 또는 가짜 이미지 G(z)
-- **출력**: 실제일 확률 D(x) 또는 D(G(z))
-
-<img src="https://miro.medium.com/max/1400/1*IZGu6tkoYVN_hEZVdc-uNQ.png" alt="GAN Architecture" width="600" style="display: block; margin: 20px auto; border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.1);">
-
-## 학습 과정
-
-### 1. Discriminator 학습
-```python
-# 실제 데이터에 대한 손실
-d_loss_real = -log(D(real_images))
-
-# 가짜 데이터에 대한 손실
-d_loss_fake = -log(1 - D(G(noise)))
-
-# 전체 Discriminator 손실
-d_loss = d_loss_real + d_loss_fake
-```
-
-### 2. Generator 학습
-```python
-# Generator는 Discriminator를 속이려 함
-g_loss = -log(D(G(noise)))
-```
-
-## 실험 결과
-
-### 데이터셋별 성능
-| 데이터셋 | 해상도 | 품질 점수 |
-|----------|--------|-----------|
-| MNIST | 28x28 | 0.95 |
-| CIFAR-10 | 32x32 | 0.87 |
-| ImageNet | 64x64 | 0.82 |
-
-### 생성된 이미지 예시
-<img src="https://miro.medium.com/max/1400/1*_CkXj0W3vQmWmJqJGk_0Lg.png" alt="Generated Images" width="500" style="display: block; margin: 20px auto; border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.1);">
-
-## 기술적 도전과제
-
-### 1. 학습 안정성
-- **Mode Collapse**: 생성자가 제한된 패턴만 생성
-- **Gradient Vanishing**: 학습 초기에 발생하는 문제
-- **Nash Equilibrium**: 두 네트워크의 균형점 찾기
-
-### 2. 해결 방법
-- **Wasserstein GAN**: 새로운 손실 함수 도입
-- **DCGAN**: 딥 컨볼루션 구조 적용
-- **Progressive GAN**: 점진적 해상도 증가
-
-## 응용 분야
-
-### 이미지 생성
-- **StyleGAN**: 고품질 얼굴 이미지 생성
-- **BigGAN**: 대규모 이미지 생성
-- **CycleGAN**: 스타일 변환
-
-### 기타 분야
-- **텍스트 생성**: SeqGAN, TextGAN
-- **음성 합성**: WaveGAN, MelGAN
-- **3D 모델링**: 3D-GAN', 4),
-
-('YOLO: Real-Time Object Detection - 상세 내용', 'Joseph Redmon, Santosh Divvala, Ross Girshick, Ali Farhadi', '# YOLO: 실시간 객체 탐지 시스템
-
-## 핵심 아이디어
-
-### 단일 단계 탐지 (One-Stage Detection)
-기존의 **two-stage** 방식과 달리, YOLO는 **single-stage** 방식입니다:
-
-- **Two-Stage**: R-CNN, Fast R-CNN, Faster R-CNN
-- **Single-Stage**: YOLO, SSD, RetinaNet
-
-### 그리드 기반 접근법
-이미지를 **S×S 그리드**로 분할하여 각 셀에서 객체를 탐지합니다.
-
-<img src="https://miro.medium.com/max/1400/1*RqKs7YtQwWtKJqHfFJw5MQ.png" alt="YOLO Grid" width="500" style="display: block; margin: 20px auto; border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.1);">
-
-## 아키텍처 상세
-
-### 네트워크 구조
-```
-Input: 448×448×3
-↓
-24 Convolutional Layers
-↓
-2 Fully Connected Layers
-↓
-Output: 7×7×30
-```
-
-### 출력 형식
-각 그리드 셀마다 다음 정보를 예측:
-
-- **바운딩 박스**: (x, y, w, h) - 4개 값
-- **신뢰도**: objectness score - 1개 값
-- **클래스 확률**: 20개 클래스 - 20개 값
-
-### 총 25개 값 × 7×7 그리드 = 1225개 출력
-
-## 학습 과정
-
-### 손실 함수
-```
-Loss = λ_coord × Coordinate Loss + 
-       Objectness Loss + 
-       λ_noobj × No-Object Loss + 
-       Classification Loss
-```
-
-### 좌표 손실
-```python
-def coordinate_loss(pred_xy, true_xy, pred_wh, true_wh):
-    xy_loss = MSE(pred_xy, true_xy)
-    wh_loss = MSE(sqrt(pred_wh), sqrt(true_wh))
-    return xy_loss + wh_loss
-```
-
-## 성능 비교
-
-### 속도 vs 정확도
-| 모델 | FPS | mAP | 정확도 순위 |
-|------|-----|-----|-------------|
-| R-CNN | 0.1 | 66.0 | 1st |
-| Fast R-CNN | 0.5 | 70.0 | 2nd |
-| Faster R-CNN | 7.0 | 73.2 | 3rd |
-| **YOLO** | **45.0** | **63.4** | **4th** |
-
-### 실시간 처리 능력
-<img src="https://miro.medium.com/max/1400/1*_CkXj0W3vQmWmJqJGk_0Lg.png" alt="YOLO Speed Comparison" width="600" style="display: block; margin: 20px auto; border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.1);">
-
-## 장단점
-
-### 장점
-- **실시간 처리**: 45 FPS로 실시간 객체 탐지
-- **전역적 컨텍스트**: 전체 이미지를 한 번에 분석
-- **적은 오탐**: 배경 오탐률이 낮음
-
-### 단점
-- **정확도**: 작은 객체 탐지 성능 부족
-- **위치 정확도**: 바운딩 박스 정확도 상대적으로 낮음
-- **클래스 불균형**: 드문 클래스 탐지 어려움
-
-## 후속 연구
-
-### YOLO v2 (YOLO9000)
-- **고해상도**: 448×448 → 416×416
-- **Anchor Boxes**: k-means 클러스터링으로 앵커 박스 최적화
-- **다중 스케일**: 다양한 해상도에서 훈련
-
-### YOLO v3
-- **다중 스케일 예측**: 3개 다른 스케일에서 예측
-- **더 나은 백본**: Darknet-53 사용
-- **FPN**: Feature Pyramid Network 적용
-
-### YOLO v4/v5
-- **Bag of Freebies**: 훈련 시 개선 기법들
-- **Bag of Specials**: 추론 시 개선 기법들
-- **AutoML**: 자동 아키텍처 탐색', 5);
+INSERT INTO paper_content (content_title, content, `order`, paper_id) VALUES
+-- Attention Is All You Need (Transformer)
+('Abstract', '# Abstract\n\n지배적인 시퀀스 변환 모델들은 인코더와 디코더를 포함하는 복잡한 순환 신경망이나 컨볼루션 신경망을 기반으로 합니다. 최고 성능을 보이는 모델들은 또한 어텐션 메커니즘을 통해 인코더와 디코더를 연결합니다. 우리는 순환과 컨볼루션을 완전히 배제하고 오직 어텐션 메커니즘만을 기반으로 하는 새로운 간단한 네트워크 아키텍처인 **Transformer**를 제안합니다.\n\n두 개의 기계 번역 작업에서의 실험은 이러한 모델들이 품질 면에서 우수하면서도 더 병렬화 가능하고 훈련 시간이 훨씬 적게 걸린다는 것을 보여줍니다. 우리의 모델은 WMT 2014 영어-독일어 번역 작업에서 28.4 BLEU를 달성하여, 앙상블을 포함한 기존 최고 결과보다 2 BLEU 이상 향상되었습니다. WMT 2014 영어-프랑스어 번역 작업에서는 8개 GPU에서 3.5일간 훈련한 후 41.8의 새로운 단일 모델 최고 BLEU 점수를 달성했으며, 이는 문헌의 최고 모델들의 훈련 비용의 일부에 불과합니다.\n\n우리는 Transformer가 대량의 훈련 데이터로 영어 구문 분석에 성공적으로 적용함으로써 다른 작업에도 잘 일반화된다는 것을 보여줍니다.', 1, 1),
+('Introduction', '# Introduction\n\n## 기존 접근 방식의 한계\n\n순환 신경망, 특히 **LSTM(Long Short-Term Memory)**과 **GRU(Gated Recurrent Neural Networks)**는 언어 모델링과 기계 번역과 같은 시퀀스 모델링 및 변환 문제에서 최첨단 접근 방식으로 확고히 자리잡았습니다. 그 이후로 순환 언어 모델과 인코더-디코더 아키텍처의 경계를 넓히기 위한 수많은 노력이 계속되었습니다.\n\n## 순차적 처리의 문제점\n\n순환 모델들은 일반적으로 입력 및 출력 시퀀스의 심볼 위치를 따라 계산을 분해합니다. 위치를 계산 시간의 단계에 맞추면, 이전 숨겨진 상태 h<sub>t-1</sub>과 위치 t의 입력의 함수로서 숨겨진 상태 h<sub>t</sub>의 시퀀스를 생성합니다. 이러한 본질적으로 순차적인 특성은 훈련 예제 내에서 병렬화를 방해하며, 이는 더 긴 시퀀스 길이에서 메모리 제약이 예제 간 배치를 제한하기 때문에 중요해집니다.\n\n최근 연구들은 조건부 계산을 통해 계산 효율성에서 상당한 개선을 달성했으며, 일부 경우에는 모델 성능도 향상시켰습니다. 그러나 근본적인 계산 제약은 여전히 남아있습니다.', 2, 1),
+('Model Architecture', '# Model Architecture\n\n## 인코더-디코더 구조\n\n대부분의 경쟁력 있는 신경 시퀀스 변환 모델들은 인코더-디코더 구조를 가지고 있습니다. 여기서 인코더는 심볼 표현의 입력 시퀀스 (x<sub>1</sub>, ..., x<sub>n</sub>)을 연속 표현의 시퀀스 z = (z<sub>1</sub>, ..., z<sub>n</sub>)에 매핑합니다. z가 주어지면, 디코더는 한 번에 하나의 요소씩 심볼의 출력 시퀀스 (y<sub>1</sub>, ..., y<sub>m</sub>)을 생성합니다. 각 단계에서 모델은 자동 회귀적이며, 다음을 생성할 때 이전에 생성된 심볼들을 추가 입력으로 소비합니다.\n\n## Transformer의 핵심 구성 요소\n\n**Transformer**는 인코더와 디코더 모두에 대해 스택된 자기 어텐션과 포인트별 완전 연결 계층을 사용하여 이 전체 아키텍처를 따릅니다.\n\n<img src="https://miro.medium.com/max/1400/1*BHzGVskWGS_3jEcYYi6miQ.png" alt="Transformer Architecture" style="max-width: 100%; height: auto; margin: 20px 0;" />', 3, 1),
+('Experiments', '# Experiments\n\n## 데이터셋 및 전처리\n\n우리는 약 450만 개의 문장 쌍으로 구성된 표준 WMT 2014 영어-독일어 데이터셋에서 모델을 훈련했습니다. 문장들은 약 37,000개의 토큰의 공유 소스-타겟 어휘를 가진 바이트 쌍 인코딩을 사용하여 인코딩되었습니다. 영어-프랑스어의 경우, 36M 문장으로 구성된 훨씬 큰 WMT 2014 영어-프랑스어 데이터셋을 사용했으며, 토큰을 32,000개의 워드피스 어휘로 분할했습니다.\n\n## 훈련 설정\n\n문장 쌍들은 대략적인 시퀀스 길이에 따라 함께 배치되었습니다. 각 훈련 배치는 약 25,000개의 소스 토큰과 25,000개의 타겟 토큰을 포함하는 문장 쌍 세트를 포함했습니다.\n\n**주요 실험 설정:**\n- **데이터셋**: WMT 2014 English-German (4.5M pairs)\n- **인코딩**: Byte-pair encoding (37K shared vocabulary)\n- **배치 크기**: ~25K source tokens + ~25K target tokens', 4, 1),
+('Results', '# Results\n\n## 번역 성능\n\nWMT 2014 영어-독일어 번역 작업에서, 큰 Transformer 모델(표 2의 Transformer (big))은 앙상블을 포함한 이전에 보고된 최고 모델들보다 2.0 BLEU 이상 우수한 성능을 보이며, 28.4의 새로운 최고 BLEU 점수를 달성했습니다. 이 모델의 구성은 표 3의 하단에 나열되어 있습니다. 훈련은 8개의 P100 GPU에서 3.5일이 걸렸습니다.\n\n## 효율성 비교\n\n우리의 기본 모델조차도 모든 이전에 발표된 모델들과 앙상블을 능가하며, 경쟁 모델들의 훈련 비용의 일부에 불과합니다.\n\n**주요 성과:**\n- **BLEU Score**: 28.4 (English-German)\n- **Training Time**: 3.5 days on 8 P100 GPUs\n- **Cost Efficiency**: Fraction of competitive models', 5, 1),
+
+-- BERT: Pre-training of Deep Bidirectional Transformers
+('Abstract', '# Abstract\n\n우리는 **BERT(Bidirectional Encoder Representations from Transformers)**라는 새로운 언어 표현 모델을 소개합니다. 최근의 언어 표현 모델들과 달리, BERT는 모든 계층에서 좌우 컨텍스트를 공동으로 조건화하여 라벨이 없는 텍스트에서 깊은 양방향 표현을 사전 훈련하도록 설계되었습니다.\n\n결과적으로, 사전 훈련된 BERT 모델은 단 하나의 추가 출력 계층으로 미세 조정하여 질문 답변 및 언어 추론과 같은 광범위한 작업에 대해 실질적인 작업별 아키텍처 수정 없이 최첨단 모델을 생성할 수 있습니다. BERT는 개념적으로 간단하면서도 경험적으로 강력합니다.\n\n11개의 자연어 처리 작업에서 새로운 최첨단 결과를 얻었으며, GLUE 점수를 80.5%(7.7% 절대 개선), MultiNLI 정확도를 86.7%(4.6% 절대 개선), SQuAD v1.1 질문 답변 테스트 F1을 93.2(1.5점 절대 개선), SQuAD v2.0 테스트 F1을 83.1(5.1점 절대 개선)로 향상시켰습니다.', 1, 2),
+('Introduction', '# Introduction\n\n## 언어 모델 사전 훈련의 중요성\n\n언어 모델 사전 훈련은 많은 자연어 처리 작업을 개선하는 데 효과적인 것으로 입증되었습니다. 여기에는 문장을 전체적으로 분석하여 문장 간의 관계를 예측하는 것을 목표로 하는 자연어 추론 및 패러프레이징과 같은 문장 수준 작업과, 모델이 토큰 수준에서 세밀한 출력을 생성해야 하는 명명된 엔티티 인식 및 질문 답변과 같은 토큰 수준 작업이 포함됩니다.\n\n## 기존 접근 방식의 한계\n\n사전 훈련된 언어 표현을 다운스트림 작업에 적용하는 두 가지 기존 전략이 있습니다: **특징 기반(feature-based)**과 **미세 조정(fine-tuning)**입니다. ELMo와 같은 특징 기반 접근 방식은 사전 훈련된 표현을 추가 특징으로 포함하는 작업별 아키텍처를 사용합니다. OpenAI GPT와 같은 미세 조정 접근 방식은 최소한의 작업별 매개변수를 도입하고 모든 사전 훈련된 매개변수를 단순히 미세 조정하여 다운스트림 작업에서 훈련됩니다.', 2, 2),
+('BERT', '# BERT\n\n## 프레임워크 개요\n\n이 섹션에서 BERT와 그 상세한 구현을 소개합니다. 우리의 프레임워크에는 두 단계가 있습니다: **사전 훈련(pre-training)**과 **미세 조정(fine-tuning)**입니다.\n\n## 사전 훈련과 미세 조정\n\n사전 훈련 중에는 모델이 다양한 사전 훈련 작업에 대해 라벨이 없는 데이터로 훈련됩니다. 미세 조정을 위해 BERT 모델은 먼저 사전 훈련된 매개변수로 초기화되고, 모든 매개변수는 다운스트림 작업의 라벨이 있는 데이터를 사용하여 미세 조정됩니다. 각 다운스트림 작업은 동일한 사전 훈련된 매개변수로 초기화되더라도 별도의 미세 조정된 모델을 가집니다.\n\n<img src="https://miro.medium.com/max/1400/1*S3Yl1ti6j1kmyXG2D8S3FQ.png" alt="BERT Architecture" style="max-width: 100%; height: auto; margin: 20px 0;" />\n\n이 섹션에서는 질문 답변 예제를 실행 예제로 사용할 것입니다.', 3, 2),
+('Experiments', '# Experiments\n\n## 다운스트림 작업 성능\n\n우리는 11개의 NLP 작업에 대한 BERT 미세 조정 결과를 제시합니다. 우리의 일반적인 작업 불가지론적 모델은 작업별 아키텍처보다 큰 차이로 우수한 성능을 보입니다. 최고 성능 시스템은 연구된 11개 작업 중 9개에서 새로운 최첨단 결과를 얻었습니다.\n\n## 성능 비교\n\n특정 경우에는 우리의 작업별 미세 조정 접근 방식이 특징 기반 접근 방식보다 4.5% 절대 개선을 얻었습니다. 110M 매개변수 모델에도 불구하고, BERT Large는 기존 문헌과 비교하여 가장 큰 모델은 아닙니다. 그러나 이는 라벨이 없는 텍스트의 대규모 코퍼스에서 사전 훈련하여 깊은 양방향 표현을 생성하는 데 사용된 가장 큰 모델입니다.\n\n**주요 실험 결과:**\n- **GLUE Score**: 80.5% (7.7% 절대 개선)\n- **MultiNLI Accuracy**: 86.7% (4.6% 절대 개선)\n- **SQuAD v1.1 F1**: 93.2 (1.5점 절대 개선)', 4, 2),
+('Ablation Studies', '# Ablation Studies\n\n## 연구 목적\n\n우리는 상대적 중요성을 더 잘 이해하기 위해 BERT의 여러 측면에 대해 **어블레이션 연구(ablation studies)**를 수행합니다. 추가 어블레이션 연구는 부록 C에서 찾을 수 있습니다.\n\n## 실험 설정\n\n우리는 비교를 위해 OpenAI GPT와 동일한 크기인 **BERT<sub>BASE</sub>**에 집중합니다. 효과는 MNLI의 검증 세트에서 입증됩니다. 우리는 이전 실험과 동일한 미세 조정 절차와 하이퍼파라미터를 사용합니다.\n\n**어블레이션 연구 결과:**\n- **No NSP**: -2.5% 성능 저하\n- **No MLM**: -3.3% 성능 저하\n- **LTR + No NSP**: -5.5% 성능 저하', 5, 2),
+
+-- ResNet: Deep Residual Learning for Image Recognition
+('Abstract', '# Abstract\n\n더 깊은 신경망은 훈련하기가 더 어렵습니다. 우리는 이전에 사용된 것보다 훨씬 더 깊은 네트워크의 훈련을 용이하게 하기 위한 **잔차 학습(residual learning)** 프레임워크를 제시합니다. 우리는 계층 입력을 참조하여 계층을 잔차 함수를 학습하도록 명시적으로 재구성하며, 참조되지 않은 함수를 학습하는 대신 사용합니다.\n\n우리는 이러한 잔차 네트워크가 최적화하기 쉽고 상당히 증가된 깊이에서 정확도를 얻을 수 있다는 것을 보여주는 포괄적인 경험적 증거를 제공합니다. ImageNet 데이터셋에서 우리는 최대 152개 계층의 깊이를 가진 잔차 네트워크를 평가했으며, 이는 VGG 네트워크보다 8배 더 깊지만 여전히 더 낮은 복잡성을 가집니다.\n\n이러한 잔차 네트워크의 앙상블은 ImageNet 테스트 세트에서 3.57% 오류를 달성했습니다. 이 결과는 ILSVRC 2015 분류 작업에서 1위를 차지했습니다. 우리는 또한 100개와 1000개 계층으로 CIFAR-10에 대한 분석을 제시합니다.', 1, 3),
+('Introduction', '# Introduction\n\n## 깊은 신경망의 발전\n\n깊은 컨볼루션 신경망은 이미지 분류에서 일련의 돌파구를 이끌어왔습니다. 깊은 네트워크는 자연스럽게 낮은/중간/높은 수준의 특징과 분류기를 엔드투엔드 다층 방식으로 통합하며, 특징의 "수준"은 쌓인 계층의 수(깊이)에 의해 풍부해질 수 있습니다.\n\n## 깊이의 중요성\n\n최근 증거는 네트워크 깊이가 매우 중요하다는 것을 보여주며, 도전적인 ImageNet 데이터셋의 선도적인 결과들은 모두 16개에서 30개의 깊이를 가진 "매우 깊은" 모델을 활용합니다. 많은 다른 중요한 시각 인식 작업들도 매우 깊은 모델로부터 크게 혜택을 받았습니다.\n\n<img src="https://miro.medium.com/max/1400/1*D0F3UItQv1n8ddwnz_KQjA.png" alt="ResNet Architecture" style="max-width: 100%; height: auto; margin: 20px 0;" />', 2, 3),
+('Deep Residual Learning', '# Deep Residual Learning\n\n## 잔차 학습의 수학적 기초\n\nH(x)를 몇 개의 쌓인 계층(반드시 전체 네트워크일 필요는 없음)에 의해 맞춰질 기본 매핑으로 고려해 보겠습니다. 여기서 x는 이러한 계층들 중 첫 번째 계층의 입력을 나타냅니다. 여러 비선형 계층이 복잡한 함수를 점근적으로 근사할 수 있다고 가정한다면, 이는 잔차 함수, 즉 H(x) − x(입력과 출력이 동일한 차원이라고 가정)를 점근적으로 근사할 수 있다고 가정하는 것과 동일합니다.\n\n## 잔차 함수의 정의\n\n따라서 쌓인 계층이 H(x)를 근사할 것으로 기대하는 대신, 우리는 이러한 계층들이 잔차 함수 F(x) := H(x) − x를 근사하도록 명시적으로 합니다. 원래 함수는 따라서 F(x) + x가 됩니다. 두 형태 모두 원하는 함수를 점근적으로 근사할 수 있어야 하지만(가정된 대로), 학습의 용이성은 다를 수 있습니다.\n\n**잔차 블록의 핵심 아이디어:**\n- **Skip Connection**: 입력을 출력에 직접 더함\n- **Residual Function**: F(x) = H(x) - x\n- **Identity Mapping**: x + F(x) = H(x)', 3, 3),
+('Experiments', '# Experiments\n\n## 데이터셋 및 평가\n\n우리는 1000개 클래스로 구성된 ImageNet 2012 분류 데이터셋에서 우리의 방법을 평가합니다. 우리는 128만 개의 훈련 이미지에서 모델을 훈련하고, 5만 개의 검증 이미지에서 평가합니다. 우리는 또한 테스트 서버에서 보고된 10만 개의 테스트 이미지에 대한 최종 결과를 얻습니다.\n\n## 훈련 설정\n\n우리는 top-1과 top-5 오류율을 모두 평가합니다. 우리는 문헌에서 찾을 수 있는 최고의 방법들과 비교합니다. 우리는 훈련을 위해 표준 데이터 증강을 채택합니다. 이미지는 스케일 증강을 위해 더 짧은 쪽이 [256, 480]에서 무작위로 샘플링되도록 크기가 조정됩니다. 224×224 크롭은 이미지나 그 수평 뒤집기에서 무작위로 샘플링되며, 픽셀별 평균이 뺍니다.\n\n**실험 설정:**\n- **데이터셋**: ImageNet 2012 (1000 classes)\n- **훈련 이미지**: 1.28M\n- **검증 이미지**: 50K\n- **배치 크기**: 256\n- **데이터 증강**: Scale [256, 480], 224×224 crop', 4, 3),
+('Results', '# Results\n\n## 성능 평가\n\n우리는 ImageNet 검증 세트에서 결과를 보여주고, 선도적인 방법들과 비교합니다. top-5 오류는 중앙 크롭으로 측정됩니다. VGG 네트워크의 관례를 따라, 우리는 10-크롭 테스트를 사용하여 모델을 평가합니다.\n\n## 주요 발견\n\n우리는 또한 GoogLeNet의 최선의 관례를 사용하여 중앙 크롭과 10-크롭 결과를 모두 보여주며 평가합니다. 우리는 다음을 보여줍니다:\n\n1. **우리의 극도로 깊은 잔차 네트워크는 최적화하기 쉽지만**, 대응하는 "일반" 네트워크(단순히 계층을 쌓는 것)는 깊이가 증가할 때 더 높은 훈련 오류를 보입니다.\n\n2. **우리의 깊은 잔차 네트워크는 크게 증가된 깊이에서 정확도 향상을 쉽게 즐길 수 있으며**, 이전 네트워크보다 훨씬 더 나은 결과를 생성합니다.\n\n**주요 성과:**\n- **Top-5 Error**: 3.57% (ImageNet)\n- **ILSVRC 2015**: 1st place\n- **Depth**: Up to 152 layers', 5, 3),
+
+-- Generative Adversarial Networks
+('Abstract', '# Abstract\n\n우리는 적대적 과정을 통해 생성 모델을 추정하기 위한 새로운 프레임워크를 제안합니다. 이 프레임워크에서는 두 개의 모델을 동시에 훈련합니다: 데이터 분포를 포착하는 생성 모델 G와 샘플이 G가 아닌 훈련 데이터에서 나왔을 확률을 추정하는 판별 모델 D입니다.\n\nG의 훈련 절차는 D가 실수할 확률을 최대화하는 것입니다. 이 프레임워크는 미니맥스 2인용 게임에 해당합니다. 임의의 함수 G와 D의 공간에서, G가 훈련 데이터 분포를 복구하고 D가 모든 곳에서 1/2과 같은 고유한 해가 존재합니다.\n\nG와 D가 다층 퍼셉트론으로 정의되는 경우, 전체 시스템은 역전파로 훈련될 수 있습니다. 훈련이나 샘플 생성 중에 마르코프 체인이나 펼쳐진 근사 추론 네트워크가 필요하지 않습니다. 실험은 생성된 샘플의 정성적 및 정량적 평가를 통해 프레임워크의 잠재력을 보여줍니다.', 1, 4),
+('Introduction', '# Introduction\n\n## 딥러닝의 목표\n\n딥러닝의 약속은 자연 이미지, 음성을 포함한 오디오 파형, 자연어 코퍼스의 심볼과 같은 인공지능 응용 프로그램에서 접하는 데이터 유형에 대한 확률 분포를 나타내는 풍부하고 계층적인 모델을 발견하는 것입니다.\n\n## 기존 접근 방식의 한계\n\n지금까지 딥러닝에서 가장 놀라운 성공은 판별 모델, 보통 고차원의 풍부한 감각 입력을 클래스 레이블에 매핑하는 것과 관련이 있었습니다. 이러한 놀라운 성공은 주로 역전파와 드롭아웃 알고리즘을 기반으로 하며, 특히 잘 동작하는 그래디언트를 가진 조각별 선형 단위를 사용합니다.\n\n깊은 생성 모델은 최대 가능도 추정 및 관련 전략에서 발생하는 많은 다루기 어려운 확률적 계산을 근사하는 어려움과 생성 맥락에서 조각별 선형 단위의 이점을 활용하는 어려움으로 인해 덜한 영향을 미쳤습니다.', 2, 4),
+('Adversarial Nets', '# Adversarial Nets\n\n## 프레임워크 개요\n\n모델이 다층 퍼셉트론일 때, 적대적 모델링 프레임워크가 가장 직관적으로 적용됩니다. 데이터 x에 대한 생성기의 분포 p<sub>g</sub>를 학습하기 위해, 우리는 입력 노이즈 변수 p<sub>z</sub>(z)에 대한 사전을 정의하고, 그 다음 데이터 공간에 대한 매핑을 G(z; θ<sub>g</sub>)로 나타냅니다. 여기서 G는 매개변수 θ<sub>g</sub>를 가진 다층 퍼셉트론으로 표현되는 미분 가능한 함수입니다.\n\n## 생성자와 판별자\n\n우리는 또한 단일 스칼라를 출력하는 두 번째 다층 퍼셉트론 D(x; θ<sub>d</sub>)를 정의합니다. D(x)는 x가 p<sub>g</sub>가 아닌 데이터에서 나왔을 확률을 나타냅니다.\n\n<img src="https://miro.medium.com/max/1400/1*IZQ3XQGhJgoXaLgfa8m-4A.png" alt="GAN Architecture" style="max-width: 100%; height: auto; margin: 20px 0;" />\n\n**GAN의 핵심 아이디어:**\n- **Generator (G)**: 노이즈에서 실제와 같은 데이터 생성\n- **Discriminator (D)**: 실제 데이터와 생성된 데이터 구분\n- **Adversarial Training**: G와 D의 경쟁적 학습', 3, 4),
+('Theoretical Results', '# Theoretical Results\n\n## 수렴성 분석\n\n생성기 G는 z ∼ p<sub>z</sub>일 때 얻은 샘플 G(z)의 분포로서 확률 분포 p<sub>g</sub>를 암묵적으로 정의합니다. 따라서 충분한 용량과 훈련 시간이 주어진다면 알고리즘 1이 p<sub>data</sub>의 좋은 추정자로 수렴하기를 원합니다.\n\n## 이론적 보장\n\n이 섹션의 결과는 비모수적 설정에서 수행됩니다. 예를 들어, 우리는 확률 밀도 함수의 공간에서 수렴을 연구함으로써 무한한 용량을 가진 모델을 나타냅니다.\n\n**이론적 보장:**\n- **Convergence**: 충분한 용량에서 최적해로 수렴\n- **Uniqueness**: 고유한 해의 존재\n- **Optimality**: G가 실제 분포를 복구, D가 1/2이 됨', 4, 4),
+('Experiments', '# Experiments\n\n## 데이터셋 및 모델 설정\n\n우리는 MNIST, Toronto Face Database (TFD), CIFAR-10을 포함한 다양한 데이터셋에서 적대적 네트워크를 훈련했습니다. 생성기 네트워크는 정류 선형 활성화와 시그모이드 활성화의 혼합을 사용했으며, 판별기 네트워크는 맥스아웃 활성화를 사용했습니다.\n\n## 훈련 세부사항\n\n드롭아웃은 판별기 네트워크 훈련에 적용되었습니다. 우리의 이론적 프레임워크는 생성기의 중간 계층에서 드롭아웃과 다른 노이즈의 사용을 허용하지만, 우리는 노이즈를 생성기 네트워크의 가장 하단 계층에만 입력으로 사용했습니다.\n\n**실험 결과:**\n- **MNIST**: 고품질 숫자 이미지 생성\n- **TFD**: 사실적인 얼굴 이미지 생성\n- **CIFAR-10**: 다양한 객체 이미지 생성', 5, 4),
+
+-- YOLO: Real-Time Object Detection
+('Abstract', '# Abstract\n\n우리는 객체 탐지를 위한 새로운 접근 방식인 **YOLO(You Only Look Once)**를 제시합니다. 이전의 객체 탐지 작업들은 분류기를 탐지 수행을 위해 재활용했습니다. 대신, 우리는 객체 탐지를 공간적으로 분리된 바운딩 박스와 관련 클래스 확률에 대한 회귀 문제로 프레임합니다.\n\n단일 신경망이 전체 이미지에서 한 번의 평가로 바운딩 박스와 클래스 확률을 직접 예측합니다. 전체 탐지 파이프라인이 단일 네트워크이기 때문에, 탐지 성능에 대해 직접 엔드투엔드로 최적화할 수 있습니다.\n\n우리의 통합 아키텍처는 극도로 빠릅니다. 우리의 기본 YOLO 모델은 초당 45프레임으로 실시간 이미지 처리를 수행합니다. 네트워크의 더 작은 버전인 Fast YOLO는 초당 놀라운 155프레임을 처리하면서도 다른 실시간 탐지기보다 두 배의 mAP를 달성합니다.\n\n최첨단 탐지 시스템과 비교하여, YOLO는 더 많은 위치 오류를 만들지만 배경에서의 거짓 양성을 예측할 가능성이 적습니다. 마지막으로, YOLO는 객체의 매우 일반적인 표현을 학습합니다. 자연 이미지에서 예술 작품과 같은 다른 도메인으로 일반화할 때 DPM과 R-CNN을 포함한 다른 탐지 방법들을 능가합니다.', 1, 5),
+('Introduction', '# Introduction\n\n## 인간 시각 시스템의 영감\n\n인간은 이미지를 한 번 보고 즉시 이미지에 어떤 객체들이 있는지, 어디에 있는지, 어떻게 상호작용하는지 알 수 있습니다. 인간의 시각 시스템은 빠르고 정확하여, 우리가 의식적인 생각 없이도 운전과 같은 복잡한 작업을 수행할 수 있게 합니다.\n\n## 실시간 객체 탐지의 중요성\n\n빠르고 정확한 객체 탐지 알고리즘은 컴퓨터가 특수 센서 없이도 자동차를 운전할 수 있게 하고, 보조 장치가 인간 사용자에게 실시간 장면 정보를 전달할 수 있게 하며, 범용 목적의 반응형 로봇 시스템의 잠재력을 해방시킬 수 있습니다.\n\n<img src="https://miro.medium.com/max/1400/1*RqXFpi9wqbuSuCr6l29dyw.png" alt="YOLO Detection" style="max-width: 100%; height: auto; margin: 20px 0;" />', 2, 5),
+('Unified Detection', '# Unified Detection\n\n## 통합 아키텍처\n\n우리는 객체 탐지의 개별 구성 요소들을 단일 신경망으로 통합합니다. 우리의 네트워크는 전체 이미지의 특징을 사용하여 바운딩 박스를 예측합니다. 또한 이러한 박스들에 대한 클래스 확률도 예측합니다. YOLO는 전체 이미지에서 훈련하고 탐지 성능을 직접 최적화합니다.\n\n## 주요 이점\n\n이 통합 설계는 전통적인 객체 탐지 방법들보다 여러 이점을 제공합니다:\n\n1. **YOLO는 극도로 빠릅니다**. 탐지를 회귀 문제로 프레임하기 때문에 복잡한 파이프라인이 필요하지 않습니다. 테스트 시간에 새로운 이미지에서 우리의 신경망을 단순히 실행하여 탐지를 예측합니다.\n\n2. **YOLO는 예측할 때 이미지에 대해 전역적으로 추론합니다**. 슬라이딩 윈도우와 지역 제안 기반 기술과 달리, YOLO는 훈련과 테스트 시간에 전체 이미지를 보므로 클래스와 그 외관에 대한 컨텍스트 정보를 암묵적으로 인코딩합니다.\n\n3. **YOLO는 객체의 일반화 가능한 표현을 학습합니다**. 자연 이미지에서 훈련되고 예술 작품에서 테스트될 때, YOLO는 DPM과 R-CNN과 같은 최고 탐지 방법들을 큰 차이로 능가합니다.', 3, 5),
+('Network Design', '# Network Design\n\n## 아키텍처 개요\n\n우리의 네트워크 아키텍처는 이미지 분류를 위한 GoogLeNet 모델에서 영감을 받았습니다. 우리의 네트워크는 24개의 컨볼루션 계층과 그 뒤에 2개의 완전 연결 계층을 가집니다. GoogLeNet에서 사용하는 인셉션 모듈 대신, 우리는 단순히 1 × 1 축소 계층과 그 뒤에 3 × 3 컨볼루션 계층을 사용하며, 이는 Lin et al.과 유사합니다.\n\n## Fast YOLO 변형\n\n우리는 또한 빠른 객체 탐지의 경계를 밀어붙이기 위해 설계된 YOLO의 빠른 버전을 훈련합니다. Fast YOLO는 더 적은 컨볼루션 계층(24개 대신 9개)과 그 계층들에서 더 적은 필터를 가진 신경망을 사용합니다. 네트워크 크기 외에는 YOLO와 Fast YOLO 간의 모든 훈련 및 테스트 매개변수가 동일합니다.\n\n**네트워크 구조:**\n- **24 Convolutional Layers**: 특징 추출\n- **2 Fully Connected Layers**: 최종 예측\n- **1×1 Reduction + 3×3 Convolution**: 효율적인 특징 처리', 4, 5),
+('Training', '# Training\n\n## 사전 훈련\n\n우리는 ImageNet 1000클래스 경쟁 데이터셋에서 컨볼루션 계층들을 사전 훈련합니다. 사전 훈련을 위해 우리는 그림 3의 처음 20개 컨볼루션 계층과 그 뒤에 평균 풀링 계층과 완전 연결 계층을 사용합니다. 우리는 이 네트워크를 약 일주일간 훈련하고 ImageNet 2012 검증 세트에서 단일 크롭 top-5 정확도 88%를 달성하며, 이는 Caffe의 Model Zoo의 GoogLeNet 모델들과 비교할 수 있습니다.\n\n## 탐지 훈련\n\n우리는 모든 훈련과 추론에 Darknet 프레임워크를 사용합니다. 그런 다음 모델을 탐지 수행을 위해 변환합니다. Ren et al.은 사전 훈련된 네트워크에 컨볼루션과 연결 계층을 모두 추가하면 성능이 향상될 수 있다는 것을 보여줍니다. 그들의 예를 따라, 우리는 무작위로 초기화된 가중치로 4개의 컨볼루션 계층과 2개의 완전 연결 계층을 추가합니다.\n\n**훈련 설정:**\n- **Pretraining**: ImageNet 1000-class (88% top-5 accuracy)\n- **Detection Training**: 448×448 resolution\n- **Framework**: Darknet\n- **Training Time**: ~1 week', 5, 5),
+('Results', '# Results\n\n## PASCAL VOC 성능\n\n우리는 PASCAL VOC 2007 테스트 세트에서 YOLO를 실행하고 다른 실시간 탐지 시스템들과 비교합니다. YOLO는 실시간 성능으로 63.4% mAP를 얻습니다. 우리의 Fast YOLO는 테스트 세트에서 가장 빠른 방법으로, 초당 155 FPS로 실행하면서 52.7% mAP를 달성합니다.\n\n## 다양한 데이터셋에서의 성능\n\n우리는 또한 VOC 2012에서 YOLO를 훈련하고 테스트 세트에서 57.9% mAP를 달성하며, 이는 경쟁 방법들보다 높습니다. 전체 결과는 PASCAL VOC 리더보드에서 확인할 수 있습니다. 더 도전적인 객체 카테고리를 가진 새로운 COCO 데이터셋에서 YOLO는 초당 35 FPS로 실행하면서 19.8% mAP를 달성합니다.\n\n**주요 성과:**\n- **PASCAL VOC 2007**: 63.4% mAP (real-time)\n- **Fast YOLO**: 155 FPS, 52.7% mAP\n- **PASCAL VOC 2012**: 57.9% mAP\n- **COCO**: 19.8% mAP at 35 FPS', 6, 5);
 
 -- RSS Feed 예시 데이터
 INSERT INTO rss_feeds (title, summary, writed_at, original_url, rss_url_id) VALUES
@@ -386,7 +94,7 @@ INSERT INTO rss_feeds (title, summary, writed_at, original_url, rss_url_id) VALU
 ('CNN: 사이버 보안 위협', '최신 사이버 보안 위협과 대응 방안에 대한 전문가 의견을 다룹니다.', '2024-01-14 13:10:00', 'https://cnn.com/tech/cybersecurity', 2);
 
 -- User Library 예시 데이터 (사용자가 논문을 라이브러리에 추가)
-INSERT INTO user_library (user_id, paper_content_id) VALUES
+INSERT INTO user_library (user_id, paper_id) VALUES
 (1, 1), -- 테스트 사용자가 "Attention Is All You Need" 추가
 (1, 3), -- 테스트 사용자가 "ResNet" 추가
 (1, 2), -- 테스트 사용자가 "BERT" 추가

--- a/docker/seed-data.sql
+++ b/docker/seed-data.sql
@@ -20,13 +20,30 @@ INSERT INTO rss_urls (type, url, user_id) VALUES
 ('normal', 'https://feeds.arstechnica.com/arstechnica/index', 1),
 ('youtube', 'https://www.youtube.com/feeds/videos.xml?channel_id=UCsT0YIqwnpJCM-mx7-gSA4Q', 1);
 
--- CS Papers 예시 데이터
-INSERT INTO cs_papers (title, all_categories, authors, update_date, url, abstract, summary) VALUES
-('Attention Is All You Need', 'cs.CL, cs.AI', 'Ashish Vaswani, Noam Shazeer, Niki Parmar, Jakob Uszkoreit, Llion Jones, Aidan N. Gomez, Lukasz Kaiser, Illia Polosukhin', '2017-06-12 00:00:00', 'https://arxiv.org/abs/1706.03762', 'The dominant sequence transduction models are based on complex recurrent or convolutional neural networks that include an encoder and a decoder. The best performing models also connect the encoder and decoder through an attention mechanism. We propose a new simple network architecture, the Transformer, based solely on attention mechanisms, dispensing with recurrence and convolutions entirely.', 'Transformer 아키텍처를 제안한 논문으로, RNN과 CNN 없이 attention 메커니즘만으로 구성된 모델입니다.'),
-('BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding', 'cs.CL', 'Jacob Devlin, Ming-Wei Chang, Kenton Lee, Kristina Toutanova', '2018-10-11 00:00:00', 'https://arxiv.org/abs/1810.04805', 'We introduce a new language representation model called BERT, which stands for Bidirectional Encoder Representations from Transformers. Unlike recent language representation models, BERT is designed to pre-train deep bidirectional representations from unlabeled text by jointly conditioning on both left and right context in all layers.', '양방향 Transformer를 사용한 언어 이해 모델 BERT를 제안한 논문입니다.'),
-('ResNet: Deep Residual Learning for Image Recognition', 'cs.CV', 'Kaiming He, Xiangyu Zhang, Shaoqing Ren, Jian Sun', '2015-12-10 00:00:00', 'https://arxiv.org/abs/1512.03385', 'Deeper neural networks are more difficult to train. We present a residual learning framework to ease the training of networks that are substantially deeper than those used previously. We explicitly reformulate the layers as learning residual functions with reference to the layer inputs, instead of learning unreferenced functions.', '깊은 신경망의 학습을 위한 residual learning 프레임워크를 제안한 논문입니다.'),
-('Generative Adversarial Networks', 'cs.LG, cs.AI', 'Ian J. Goodfellow, Jean Pouget-Abadie, Mehdi Mirza, Bing Xu, David Warde-Farley, Sherjil Ozair, Aaron Courville, Yoshua Bengio', '2014-06-10 00:00:00', 'https://arxiv.org/abs/1406.2661', 'We propose a new framework for estimating generative models via an adversarial process, in which we simultaneously train two models: a generative model G that captures the data distribution, and a discriminative model D that estimates the probability that a sample came from the training data rather than G.', '생성 모델과 판별 모델을 동시에 학습하는 GAN 프레임워크를 제안한 논문입니다.'),
-('YOLO: Real-Time Object Detection', 'cs.CV', 'Joseph Redmon, Santosh Divvala, Ross Girshick, Ali Farhadi', '2015-06-08 00:00:00', 'https://arxiv.org/abs/1506.02640', 'We present YOLO, a new approach to object detection. Prior work on object detection repurposes classifiers to perform detection. Instead, we frame object detection as a regression problem to spatially separated bounding boxes and associated class probabilities.', '실시간 객체 탐지를 위한 YOLO 모델을 제안한 논문입니다.');
+-- Paper Categories 예시 데이터
+INSERT INTO cs_paper_categories (name) VALUES
+('cs.CL'),
+('cs.AI'),
+('cs.CV'),
+('cs.LG');
+
+-- Papers 예시 데이터
+INSERT INTO papers (title, authors, update_date, url, abstract, summary) VALUES
+('Attention Is All You Need', 'Ashish Vaswani, Noam Shazeer, Niki Parmar, Jakob Uszkoreit, Llion Jones, Aidan N. Gomez, Lukasz Kaiser, Illia Polosukhin', '2017-06-12 00:00:00', 'https://arxiv.org/abs/1706.03762', 'The dominant sequence transduction models are based on complex recurrent or convolutional neural networks that include an encoder and a decoder. The best performing models also connect the encoder and decoder through an attention mechanism. We propose a new simple network architecture, the Transformer, based solely on attention mechanisms, dispensing with recurrence and convolutions entirely.', 'Transformer 아키텍처를 제안한 논문으로, RNN과 CNN 없이 attention 메커니즘만으로 구성된 모델입니다.'),
+('BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding', 'Jacob Devlin, Ming-Wei Chang, Kenton Lee, Kristina Toutanova', '2018-10-11 00:00:00', 'https://arxiv.org/abs/1810.04805', 'We introduce a new language representation model called BERT, which stands for Bidirectional Encoder Representations from Transformers. Unlike recent language representation models, BERT is designed to pre-train deep bidirectional representations from unlabeled text by jointly conditioning on both left and right context in all layers.', '양방향 Transformer를 사용한 언어 이해 모델 BERT를 제안한 논문입니다.'),
+('ResNet: Deep Residual Learning for Image Recognition', 'Kaiming He, Xiangyu Zhang, Shaoqing Ren, Jian Sun', '2015-12-10 00:00:00', 'https://arxiv.org/abs/1512.03385', 'Deeper neural networks are more difficult to train. We present a residual learning framework to ease the training of networks that are substantially deeper than those used previously. We explicitly reformulate the layers as learning residual functions with reference to the layer inputs, instead of learning unreferenced functions.', '깊은 신경망의 학습을 위한 residual learning 프레임워크를 제안한 논문입니다.'),
+('Generative Adversarial Networks', 'Ian J. Goodfellow, Jean Pouget-Abadie, Mehdi Mirza, Bing Xu, David Warde-Farley, Sherjil Ozair, Aaron Courville, Yoshua Bengio', '2014-06-10 00:00:00', 'https://arxiv.org/abs/1406.2661', 'We propose a new framework for estimating generative models via an adversarial process, in which we simultaneously train two models: a generative model G that captures the data distribution, and a discriminative model D that estimates the probability that a sample came from the training data rather than G.', '생성 모델과 판별 모델을 동시에 학습하는 GAN 프레임워크를 제안한 논문입니다.'),
+('YOLO: Real-Time Object Detection', 'Joseph Redmon, Santosh Divvala, Ross Girshick, Ali Farhadi', '2015-06-08 00:00:00', 'https://arxiv.org/abs/1506.02640', 'We present YOLO, a new approach to object detection. Prior work on object detection repurposes classifiers to perform detection. Instead, we frame object detection as a regression problem to spatially separated bounding boxes and associated class probabilities.', '실시간 객체 탐지를 위한 YOLO 모델을 제안한 논문입니다.');
+
+-- Paper-Category 관계 데이터
+INSERT INTO cs_paper_category_relations (paper_id, category_id) VALUES
+(1, 1), -- Attention Is All You Need - cs.CL
+(1, 2), -- Attention Is All You Need - cs.AI
+(2, 1), -- BERT - cs.CL
+(3, 3), -- ResNet - cs.CV
+(4, 4), -- GAN - cs.LG
+(4, 2), -- GAN - cs.AI
+(5, 3); -- YOLO - cs.CV
 
 -- Paper Content 예시 데이터
 INSERT INTO paper_content (title, authors, content, paper_id) VALUES
@@ -383,7 +400,11 @@ SELECT 'RSS URLs', COUNT(*) FROM rss_urls
 UNION ALL
 SELECT 'RSS Feeds', COUNT(*) FROM rss_feeds
 UNION ALL
-SELECT 'CS Papers', COUNT(*) FROM cs_papers
+SELECT 'Papers', COUNT(*) FROM papers
+UNION ALL
+SELECT 'Paper Categories', COUNT(*) FROM cs_paper_categories
+UNION ALL
+SELECT 'Paper-Category Relations', COUNT(*) FROM cs_paper_category_relations
 UNION ALL
 SELECT 'Paper Content', COUNT(*) FROM paper_content
 UNION ALL

--- a/lib/auth/userService.ts
+++ b/lib/auth/userService.ts
@@ -49,17 +49,17 @@ export async function findUserByEmail(email: string): Promise<UserWithPassword |
  *
  * @example
  * ```typescript
- * const user = await findUserById('user-123')
+ * const user = await findUserById(1)
  * if (user) {
  *   console.log(`사용자: ${user.name} (${user.email})`)
  * }
  * ```
  */
-export async function findUserById(id: string): Promise<UserData | null> {
+export async function findUserById(id: number): Promise<UserData | null> {
   try {
     await ensureDatabaseConnection();
     const userRepository = getUserRepository();
-    const user = await userRepository.findOne({ where: { id: parseInt(id) } });
+    const user = await userRepository.findOne({ where: { id: id } });
 
     if (!user) return null;
 
@@ -209,7 +209,7 @@ export async function getCurrentUser(): Promise<UserData | null> {
       return null;
     }
 
-    return await findUserById(session.userId.toString());
+    return await findUserById(session.userId);
   } catch (error) {
     console.error('현재 사용자 조회 중 오류 발생:', error);
     return null;

--- a/lib/database/entities/Paper.ts
+++ b/lib/database/entities/Paper.ts
@@ -10,6 +10,7 @@ import {
 } from 'typeorm';
 import type { PaperContent } from './PaperContent';
 import type { PaperCategory } from './PaperCategory';
+import type { UserLibrary } from './UserLibrary';
 
 @Entity('papers')
 @Index('idx_update_date', ['updateDate'])
@@ -47,4 +48,7 @@ export class Paper {
 
   @ManyToMany('PaperCategory', 'papers')
   categories!: Promise<PaperCategory[]>;
+
+  @OneToMany('UserLibrary', 'paper')
+  userLibraries!: Promise<UserLibrary[]>;
 }

--- a/lib/database/entities/Paper.ts
+++ b/lib/database/entities/Paper.ts
@@ -6,11 +6,12 @@ import {
   UpdateDateColumn,
   Index,
   OneToMany,
+  ManyToMany,
 } from 'typeorm';
 import type { PaperContent } from './PaperContent';
+import type { PaperCategory } from './PaperCategory';
 
-@Entity('cs_papers')
-@Index('idx_categories', ['allCategories'])
+@Entity('papers')
 @Index('idx_update_date', ['updateDate'])
 @Index('idx_created_at', ['createdAt'])
 export class Paper {
@@ -19,9 +20,6 @@ export class Paper {
 
   @Column({ type: 'varchar', length: 500 })
   title!: string;
-
-  @Column({ type: 'varchar', length: 200, nullable: true, name: 'all_categories' })
-  allCategories!: string;
 
   @Column({ type: 'text', nullable: true })
   authors!: string;
@@ -46,4 +44,7 @@ export class Paper {
 
   @OneToMany('PaperContent', 'paper')
   paperContents!: Promise<PaperContent[]>;
+
+  @ManyToMany('PaperCategory', 'papers')
+  categories!: Promise<PaperCategory[]>;
 }

--- a/lib/database/entities/PaperCategory.ts
+++ b/lib/database/entities/PaperCategory.ts
@@ -1,0 +1,41 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+  ManyToMany,
+  JoinTable,
+} from 'typeorm';
+import type { Paper } from './Paper';
+
+@Entity('cs_paper_categories')
+@Index('idx_category_name', ['name'])
+export class PaperCategory {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: 'varchar', length: 100, unique: true })
+  name!: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt!: Date;
+
+  @ManyToMany('Paper', 'categories')
+  @JoinTable({
+    name: 'cs_paper_category_relations',
+    joinColumn: {
+      name: 'category_id',
+      referencedColumnName: 'id',
+    },
+    inverseJoinColumn: {
+      name: 'paper_id',
+      referencedColumnName: 'id',
+    },
+  })
+  papers!: Promise<Paper[]>;
+}

--- a/lib/database/entities/PaperContent.ts
+++ b/lib/database/entities/PaperContent.ts
@@ -6,10 +6,8 @@ import {
   ManyToOne,
   JoinColumn,
   Index,
-  OneToMany,
 } from 'typeorm';
 import type { Paper } from './Paper';
-import type { UserLibrary } from './UserLibrary';
 
 @Entity('paper_content')
 @Index('idx_paper_id', ['paperId'])
@@ -18,14 +16,14 @@ export class PaperContent {
   @PrimaryGeneratedColumn()
   id!: number;
 
-  @Column({ type: 'varchar', length: 500 })
-  title!: string;
-
-  @Column({ type: 'text', nullable: true })
-  authors!: string;
+  @Column({ type: 'varchar', length: 500, name: 'content_title' })
+  contentTitle!: string;
 
   @Column({ type: 'longtext' })
   content!: string;
+
+  @Column({ type: 'int', default: 0 })
+  order!: number;
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;
@@ -36,7 +34,4 @@ export class PaperContent {
   @ManyToOne('Paper', 'paperContents')
   @JoinColumn({ name: 'paper_id' })
   paper!: Paper;
-
-  @OneToMany('UserLibrary', 'paperContent')
-  userLibraries!: Promise<UserLibrary[]>;
 }

--- a/lib/database/entities/UserLibrary.ts
+++ b/lib/database/entities/UserLibrary.ts
@@ -8,11 +8,11 @@ import {
   Index,
 } from 'typeorm';
 import type { User } from './User';
-import type { PaperContent } from './PaperContent';
+import type { Paper } from './Paper';
 
 @Entity('user_library')
 @Index('idx_user_id', ['userId'])
-@Index('idx_paper_content_id', ['paperContentId'])
+@Index('idx_paper_id', ['paperId'])
 @Index('idx_created_at', ['createdAt'])
 export class UserLibrary {
   @PrimaryGeneratedColumn()
@@ -21,8 +21,8 @@ export class UserLibrary {
   @Column({ name: 'user_id' })
   userId!: number;
 
-  @Column({ name: 'paper_content_id' })
-  paperContentId!: number;
+  @Column({ name: 'paper_id' })
+  paperId!: number;
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;
@@ -31,7 +31,7 @@ export class UserLibrary {
   @JoinColumn({ name: 'user_id' })
   user!: Promise<User>;
 
-  @ManyToOne('PaperContent', 'userLibraries')
-  @JoinColumn({ name: 'paper_content_id' })
-  paperContent!: Promise<PaperContent>;
+  @ManyToOne('Paper', 'userLibraries')
+  @JoinColumn({ name: 'paper_id' })
+  paper!: Promise<Paper>;
 }

--- a/lib/database/ormconfig.ts
+++ b/lib/database/ormconfig.ts
@@ -7,6 +7,7 @@ import { RSSFeed } from './entities/RSSFeed';
 import { PaperContent } from './entities/PaperContent';
 import { UserLibrary } from './entities/UserLibrary';
 import { UserInterests } from './entities/UserInterests';
+import { PaperCategory } from './entities/PaperCategory';
 
 // 환경 설정 검증
 validateConfig();
@@ -16,7 +17,7 @@ const databaseConfig = getDatabaseConfig();
 
 export const AppDataSource = new DataSource({
   ...databaseConfig,
-  entities: [User, Paper, RSSUrl, RSSFeed, PaperContent, UserLibrary, UserInterests],
+  entities: [User, Paper, RSSUrl, RSSFeed, PaperContent, UserLibrary, UserInterests, PaperCategory],
 });
 
 // 데이터베이스 연결 초기화

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -5,70 +5,68 @@ import { initializeRedis, closeRedis } from './redis/client';
 let isInitialized = false;
 
 export const initializeApp = async () => {
-    if (isInitialized) {
-        console.log('애플리케이션이 이미 초기화되었습니다.');
-        return;
-    }
+  if (isInitialized) {
+    console.log('애플리케이션이 이미 초기화되었습니다.');
+    return;
+  }
 
-    try {
-        console.log('애플리케이션 초기화를 시작합니다...');
-        console.log(`환경: ${process.env.NODE_ENV || 'development'}`);
+  try {
+    console.log('애플리케이션 초기화를 시작합니다...');
+    console.log(`환경: ${process.env.NODE_ENV || 'development'}`);
 
-        // 데이터베이스 초기화
-        await initializeDatabase();
+    // 데이터베이스 초기화
+    await initializeDatabase();
 
-        // Redis 초기화
-        await initializeRedis();
+    // Redis 초기화
+    await initializeRedis();
 
-        isInitialized = true;
-        console.log('애플리케이션 초기화가 완료되었습니다.');
-
-    } catch (error) {
-        console.error('애플리케이션 초기화 중 오류가 발생했습니다:', error);
-        throw error;
-    }
+    isInitialized = true;
+    console.log('애플리케이션 초기화가 완료되었습니다.');
+  } catch (error) {
+    console.error('애플리케이션 초기화 중 오류가 발생했습니다:', error);
+    throw error;
+  }
 };
 
 export const closeApp = async () => {
-    try {
-        console.log('애플리케이션 종료를 시작합니다...');
+  try {
+    console.log('애플리케이션 종료를 시작합니다...');
 
-        // 데이터베이스 연결 종료
-        await closeDatabase();
+    // 데이터베이스 연결 종료
+    await closeDatabase();
 
-        // Redis 연결 종료
-        await closeRedis();
+    // Redis 연결 종료
+    await closeRedis();
 
-        isInitialized = false;
-        console.log('애플리케이션 종료가 완료되었습니다.');
-
-    } catch (error) {
-        console.error('애플리케이션 종료 중 오류가 발생했습니다:', error);
-    }
+    isInitialized = false;
+    console.log('애플리케이션 종료가 완료되었습니다.');
+  } catch (error) {
+    console.error('애플리케이션 종료 중 오류가 발생했습니다:', error);
+  }
 };
 
 // 프로세스 종료 시 정리 작업
 process.on('SIGINT', async () => {
-    console.log('\nSIGINT 신호를 받았습니다. 애플리케이션을 종료합니다...');
-    await closeApp();
-    process.exit(0);
+  console.log('\nSIGINT 신호를 받았습니다. 애플리케이션을 종료합니다...');
+  await closeApp();
+  process.exit(0);
 });
 
 process.on('SIGTERM', async () => {
-    console.log('\nSIGTERM 신호를 받았습니다. 애플리케이션을 종료합니다...');
-    await closeApp();
-    process.exit(0);
+  console.log('\nSIGTERM 신호를 받았습니다. 애플리케이션을 종료합니다...');
+  await closeApp();
+  process.exit(0);
 });
 
 // 예상치 못한 오류 처리
 process.on('uncaughtException', async (error) => {
-    console.error('예상치 못한 오류가 발생했습니다:', error);
-    await closeApp();
-    process.exit(1);
+  console.error('예상치 못한 오류가 발생했습니다:', error);
+  await closeApp();
+  process.exit(1);
 });
 
-process.on('unhandledRejection', async (reason, promise) => {
-    console.error('처리되지 않은 Promise 거부가 발생했습니다:', reason);
-    await closeApp();
-    process.exit(1);
+process.on('unhandledRejection', async (reason) => {
+  console.error('처리되지 않은 Promise 거부가 발생했습니다:', reason);
+  await closeApp();
+  process.exit(1);
 });

--- a/lib/paper/paperService.ts
+++ b/lib/paper/paperService.ts
@@ -82,7 +82,7 @@ async function userLibraryEntityToDto(entity: UserLibraryEntity): Promise<UserLi
 function paperContentEntityToBlock(entity: PaperContentEntity): PaperContentBlock {
   return {
     id: entity.id,
-    title: `Content ${entity.order}`, // order를 기반으로 제목 생성
+    title: entity.contentTitle, // DB의 contentTitle 필드 사용
     content: entity.content,
     order: entity.order,
   };
@@ -116,7 +116,7 @@ function paperAndContentsToDetail(
     title: paper.title,
     authors,
     content: contentBlocks,
-    createdAt: paperContents[0]?.createdAt || paper.createdAt,
+    createdAt: paper.createdAt,
     publishedAt: paper.createdAt,
     url: paper.url || '',
   };

--- a/lib/paper/paperService.ts
+++ b/lib/paper/paperService.ts
@@ -3,12 +3,8 @@
  * @author Minseok kim
  */
 
-import { Paper, PaperDetail } from '@/lib/types/paper';
-import {
-  getPaperRepository,
-  getUserLibraryRepository,
-  getPaperContentRepository,
-} from '@/lib/database/repositories';
+import { Paper, PaperDetail, PaperContentBlock } from '@/lib/types/paper';
+import { getPaperRepository, getUserLibraryRepository } from '@/lib/database/repositories';
 import { Paper as PaperEntity } from '@/lib/database/entities/Paper';
 import { PaperContent as PaperContentEntity } from '@/lib/database/entities/PaperContent';
 import { ensureDatabaseConnection } from '@/lib/database/connection';
@@ -58,32 +54,69 @@ async function entityToDto(entity: PaperEntity): Promise<Paper> {
  * @private
  */
 async function userLibraryEntityToDto(entity: UserLibraryEntity): Promise<UserLibraryType> {
-  const paperContent = await entity.paperContent;
+  const paper = await entity.paper;
+
+  // authors를 배열로 파싱
+  let authors: string[] = [];
+  try {
+    authors = paper.authors ? JSON.parse(paper.authors) : [];
+  } catch {
+    authors = paper.authors ? paper.authors.split(',').map((a: string) => a.trim()) : [];
+  }
+
   return {
-    paperContentId: entity.paperContentId,
-    title: paperContent?.title || '',
-    authors: paperContent?.authors
-      ? paperContent.authors.split(',').map((a: string) => a.trim())
-      : [],
+    paperContentId: entity.paperId, // paperId로 변경
+    title: paper.title,
+    authors,
     createdAt: entity.createdAt,
   };
 }
 
 /**
- * PaperContentEntity를 PaperDetail 타입으로 변환하는 함수
+ * PaperContentEntity를 PaperContentBlock 타입으로 변환하는 함수
  *
  * @param {PaperContentEntity} entity - 변환할 PaperContent 엔티티
- * @param {PaperEntity} paper - 관련된 Paper 엔티티
+ * @returns {PaperContentBlock} 변환된 PaperContentBlock 타입
+ * @private
+ */
+function paperContentEntityToBlock(entity: PaperContentEntity): PaperContentBlock {
+  return {
+    id: entity.id,
+    title: `Content ${entity.order}`, // order를 기반으로 제목 생성
+    content: entity.content,
+    order: entity.order,
+  };
+}
+
+/**
+ * PaperEntity와 PaperContentEntity 배열을 PaperDetail 타입으로 변환하는 함수
+ *
+ * @param {PaperEntity} paper - Paper 엔티티
+ * @param {PaperContentEntity[]} paperContents - PaperContent 엔티티 배열
  * @returns {PaperDetail} 변환된 PaperDetail 타입
  * @private
  */
-function paperContentEntityToDto(entity: PaperContentEntity, paper: PaperEntity): PaperDetail {
+function paperAndContentsToDetail(
+  paper: PaperEntity,
+  paperContents: PaperContentEntity[]
+): PaperDetail {
+  // authors를 배열로 파싱
+  let authors: string[] = [];
+  try {
+    authors = paper.authors ? JSON.parse(paper.authors) : [];
+  } catch {
+    authors = paper.authors ? paper.authors.split(',').map((a: string) => a.trim()) : [];
+  }
+
+  // PaperContent를 PaperContentBlock 배열로 변환 (이미 DB에서 정렬됨)
+  const contentBlocks = paperContents.map(paperContentEntityToBlock);
+
   return {
-    paperContentId: entity.id,
-    title: entity.title,
-    authors: entity.authors ? entity.authors.split(',').map((a: string) => a.trim()) : [],
-    content: entity.content,
-    createdAt: entity.createdAt,
+    paperContentId: paper.id, // paperId를 사용
+    title: paper.title,
+    authors,
+    content: contentBlocks,
+    createdAt: paperContents[0]?.createdAt || paper.createdAt,
     publishedAt: paper.createdAt,
     url: paper.url || '',
   };
@@ -176,7 +209,7 @@ export async function getUserLibrary(
     // 사용자의 논문 라이브러리 조회 (최신순으로 정렬)
     const userLibraries = await userLibraryRepository.find({
       where: { userId: session.userId },
-      relations: ['paperContent', 'paperContent.paper'],
+      relations: ['paper'],
       skip,
       take: pageSize,
       order: {
@@ -244,27 +277,37 @@ export async function registerPaper(paperId: number): Promise<boolean> {
 
 /**
  * 논문 상세 정보를 조회하는 함수
- * @param paperContentId 논문 콘텐츠 ID
+ * @param paperId 논문 ID
  * @returns 논문 상세 정보
  */
-export async function getPaperDetail(paperContentId: number): Promise<PaperDetail | null> {
+export async function getPaperDetail(paperId: number): Promise<PaperDetail | null> {
   try {
     await ensureDatabaseConnection();
-    const paperContentRepository = getPaperContentRepository();
+    const paperRepository = getPaperRepository();
 
-    // 논문 콘텐츠와 관련된 Paper 정보를 함께 조회
-    const paperContent = await paperContentRepository.findOne({
-      where: { id: paperContentId },
-      relations: ['paper'],
+    // 논문 정보와 관련된 PaperContent들을 함께 조회 (order 순으로 정렬)
+    const paper = await paperRepository.findOne({
+      where: { id: paperId },
+      relations: {
+        paperContents: true,
+      },
+      order: {
+        paperContents: {
+          order: 'ASC',
+        },
+      },
     });
 
-    if (!paperContent || !paperContent.paper) {
-      console.error(`논문 콘텐츠를 찾을 수 없습니다: ${paperContentId}`);
+    if (!paper) {
+      console.error(`논문을 찾을 수 없습니다: ${paperId}`);
       return null;
     }
 
-    // 엔티티를 DTO로 변환
-    return paperContentEntityToDto(paperContent, paperContent.paper);
+    // Paper의 paperContents 관계에서 PaperContent 배열 가져오기 (이미 정렬됨)
+    const paperContents = await paper.paperContents;
+
+    // Paper와 PaperContent를 PaperDetail로 변환
+    return paperAndContentsToDetail(paper, paperContents);
   } catch (error) {
     console.error('논문 상세 정보 조회 중 오류 발생:', error);
     throw new Error('논문 상세 정보 조회에 실패했습니다');

--- a/lib/types/paper.ts
+++ b/lib/types/paper.ts
@@ -48,8 +48,15 @@ export interface PaperDetail {
   paperContentId: number;
   title: string;
   authors: string[];
-  content: string;
+  content: PaperContentBlock[];
   createdAt: Date;
   publishedAt: Date;
   url: string;
+}
+
+export interface PaperContentBlock {
+  id: number;
+  title: string;
+  content: string;
+  order: number;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-markdown": "^10.1.0",
+        "react-scrollspy-navigation": "^2.0.6",
         "reflect-metadata": "^0.2.2",
         "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.1",
@@ -9936,6 +9937,22 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-scrollspy-navigation": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/react-scrollspy-navigation/-/react-scrollspy-navigation-2.0.6.tgz",
+      "integrity": "sha512-BBnIEI9BsCPIMnp3z/OIEJ6mRSlDgGYf8wty5IjR8nOIhIeRhQp6eDUAKFMyHRoM2RUInA2NDu5DutIFTphoKQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/toviszsolt"
+        },
+        {
+          "type": "paypal",
+          "url": "https://www.paypal.com/paypalme/toviszsolt"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-markdown": "^10.1.0",
+    "react-scrollspy-navigation": "^2.0.6",
     "reflect-metadata": "^0.2.2",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",

--- a/tests/lib/services/paperService.test.ts
+++ b/tests/lib/services/paperService.test.ts
@@ -70,7 +70,10 @@ describe('paperService', () => {
       url: 'https://example.com/paper1',
       updateDate: new Date('2024-01-15'),
       createdAt: new Date('2024-01-15'),
-      allCategories: 'cs.AI cs.ML',
+      categories: Promise.resolve([
+        { id: 1, name: 'cs.AI' },
+        { id: 2, name: 'cs.ML' },
+      ]),
     },
     {
       id: 2,
@@ -81,7 +84,10 @@ describe('paperService', () => {
       url: 'https://example.com/paper2',
       updateDate: new Date('2024-01-20'),
       createdAt: new Date('2024-01-20'),
-      allCategories: 'cs.CL cs.AI',
+      categories: Promise.resolve([
+        { id: 3, name: 'cs.CL' },
+        { id: 1, name: 'cs.AI' },
+      ]),
     },
     {
       id: 3,
@@ -92,7 +98,10 @@ describe('paperService', () => {
       url: 'https://example.com/paper3',
       updateDate: new Date('2024-01-25'),
       createdAt: new Date('2024-01-25'),
-      allCategories: 'cs.CV cs.AI',
+      categories: Promise.resolve([
+        { id: 4, name: 'cs.CV' },
+        { id: 1, name: 'cs.AI' },
+      ]),
     },
     {
       id: 4,
@@ -103,7 +112,10 @@ describe('paperService', () => {
       url: 'https://example.com/paper4',
       updateDate: new Date('2024-01-30'),
       createdAt: new Date('2024-01-30'),
-      allCategories: 'cs.AI cs.LG',
+      categories: Promise.resolve([
+        { id: 1, name: 'cs.AI' },
+        { id: 5, name: 'cs.LG' },
+      ]),
     },
     {
       id: 5,
@@ -114,7 +126,10 @@ describe('paperService', () => {
       url: 'https://example.com/paper5',
       updateDate: new Date('2024-02-05'),
       createdAt: new Date('2024-02-05'),
-      allCategories: 'cs.AI cs.CY',
+      categories: Promise.resolve([
+        { id: 1, name: 'cs.AI' },
+        { id: 6, name: 'cs.CY' },
+      ]),
     },
   ];
 
@@ -183,7 +198,6 @@ describe('paperService', () => {
         url: 'https://example.com/paper1',
         updateDate: new Date('2024-01-15'),
         createdAt: new Date('2024-01-15'),
-        allCategories: 'cs.AI cs.ML',
       },
     },
     {
@@ -203,7 +217,6 @@ describe('paperService', () => {
         url: 'https://example.com/paper2',
         updateDate: new Date('2024-01-20'),
         createdAt: new Date('2024-01-20'),
-        allCategories: 'cs.CL cs.AI',
       },
     },
     {
@@ -223,7 +236,6 @@ describe('paperService', () => {
         url: 'https://example.com/paper3',
         updateDate: new Date('2024-01-25'),
         createdAt: new Date('2024-01-25'),
-        allCategories: 'cs.CV cs.AI',
       },
     },
   ];

--- a/tests/lib/services/paperService.test.ts
+++ b/tests/lib/services/paperService.test.ts
@@ -72,12 +72,14 @@ describe('paperService', () => {
       paperContents: Promise.resolve([
         {
           id: 1,
+          contentTitle: '서론',
           content: '이 논문은 인공지능과 머신러닝의 최신 발전 동향을 다룹니다.',
           order: 0,
           createdAt: new Date('2024-01-15'),
         },
         {
           id: 2,
+          contentTitle: '본론',
           content: '특히 딥러닝 모델의 성능 향상과 실제 응용 사례에 대해 자세히 분석합니다.',
           order: 1,
           createdAt: new Date('2024-01-15'),
@@ -100,6 +102,7 @@ describe('paperService', () => {
       paperContents: Promise.resolve([
         {
           id: 3,
+          contentTitle: '연구 배경',
           content: '자연어 처리를 위한 딥러닝 모델의 성능 향상에 대한 연구입니다.',
           order: 0,
           createdAt: new Date('2024-01-20'),
@@ -122,6 +125,7 @@ describe('paperService', () => {
       paperContents: Promise.resolve([
         {
           id: 4,
+          contentTitle: '컴퓨터 비전 개요',
           content: '컴퓨터 비전 분야에서 CNN과 Vision Transformer의 발전 과정을 다룹니다.',
           order: 0,
           createdAt: new Date('2024-01-25'),
@@ -144,6 +148,7 @@ describe('paperService', () => {
       paperContents: Promise.resolve([
         {
           id: 5,
+          contentTitle: '강화학습 기초',
           content: '강화학습을 활용한 게임 AI와 로봇 제어 시스템의 실제 응용 사례를 다룹니다.',
           order: 0,
           createdAt: new Date('2024-01-30'),
@@ -166,6 +171,7 @@ describe('paperService', () => {
       paperContents: Promise.resolve([
         {
           id: 6,
+          contentTitle: '윤리적 문제',
           content: '생성형 AI의 발전에 따른 윤리적 문제와 사회적 영향을 분석합니다.',
           order: 0,
           createdAt: new Date('2024-02-05'),
@@ -525,7 +531,7 @@ describe('paperService', () => {
       expect(Array.isArray(result?.content)).toBe(true);
       expect(result?.content).toHaveLength(2);
       expect(result?.content[0].id).toBe(1);
-      expect(result?.content[0].title).toBe('Content 0');
+      expect(result?.content[0].title).toBe('서론'); // contentTitle 필드 사용
       expect(result?.content[0].content).toBe(
         '이 논문은 인공지능과 머신러닝의 최신 발전 동향을 다룹니다.'
       );
@@ -622,12 +628,14 @@ describe('paperService', () => {
         paperContents: Promise.resolve([
           {
             id: 1,
+            contentTitle: '서론',
             content: '이 논문은 인공지능과 머신러닝의 최신 발전 동향을 다룹니다.',
             order: 0,
             createdAt: new Date('2024-01-15'),
           },
           {
             id: 2,
+            contentTitle: '본론',
             content: '특히 딥러닝 모델의 성능 향상과 실제 응용 사례에 대해 자세히 분석합니다.',
             order: 1,
             createdAt: new Date('2024-01-15'),

--- a/tests/lib/services/paperService.test.ts
+++ b/tests/lib/services/paperService.test.ts
@@ -37,14 +37,9 @@ const mockUserLibraryRepository = {
   delete: vi.fn(),
 };
 
-const mockPaperContentRepository = {
-  findOne: vi.fn(),
-};
-
 vi.mock('@/lib/database/repositories', () => ({
   getPaperRepository: vi.fn(() => mockRepository),
   getUserLibraryRepository: vi.fn(() => mockUserLibraryRepository),
-  getPaperContentRepository: vi.fn(() => mockPaperContentRepository),
 }));
 
 vi.mock('@/lib/database/ormconfig', () => ({
@@ -74,6 +69,20 @@ describe('paperService', () => {
         { id: 1, name: 'cs.AI' },
         { id: 2, name: 'cs.ML' },
       ]),
+      paperContents: Promise.resolve([
+        {
+          id: 1,
+          content: '이 논문은 인공지능과 머신러닝의 최신 발전 동향을 다룹니다.',
+          order: 0,
+          createdAt: new Date('2024-01-15'),
+        },
+        {
+          id: 2,
+          content: '특히 딥러닝 모델의 성능 향상과 실제 응용 사례에 대해 자세히 분석합니다.',
+          order: 1,
+          createdAt: new Date('2024-01-15'),
+        },
+      ]),
     },
     {
       id: 2,
@@ -87,6 +96,14 @@ describe('paperService', () => {
       categories: Promise.resolve([
         { id: 3, name: 'cs.CL' },
         { id: 1, name: 'cs.AI' },
+      ]),
+      paperContents: Promise.resolve([
+        {
+          id: 3,
+          content: '자연어 처리를 위한 딥러닝 모델의 성능 향상에 대한 연구입니다.',
+          order: 0,
+          createdAt: new Date('2024-01-20'),
+        },
       ]),
     },
     {
@@ -102,6 +119,14 @@ describe('paperService', () => {
         { id: 4, name: 'cs.CV' },
         { id: 1, name: 'cs.AI' },
       ]),
+      paperContents: Promise.resolve([
+        {
+          id: 4,
+          content: '컴퓨터 비전 분야에서 CNN과 Vision Transformer의 발전 과정을 다룹니다.',
+          order: 0,
+          createdAt: new Date('2024-01-25'),
+        },
+      ]),
     },
     {
       id: 4,
@@ -115,6 +140,14 @@ describe('paperService', () => {
       categories: Promise.resolve([
         { id: 1, name: 'cs.AI' },
         { id: 5, name: 'cs.LG' },
+      ]),
+      paperContents: Promise.resolve([
+        {
+          id: 5,
+          content: '강화학습을 활용한 게임 AI와 로봇 제어 시스템의 실제 응용 사례를 다룹니다.',
+          order: 0,
+          createdAt: new Date('2024-01-30'),
+        },
       ]),
     },
     {
@@ -130,113 +163,39 @@ describe('paperService', () => {
         { id: 1, name: 'cs.AI' },
         { id: 6, name: 'cs.CY' },
       ]),
+      paperContents: Promise.resolve([
+        {
+          id: 6,
+          content: '생성형 AI의 발전에 따른 윤리적 문제와 사회적 영향을 분석합니다.',
+          order: 0,
+          createdAt: new Date('2024-02-05'),
+        },
+      ]),
     },
   ];
 
-  // UserLibrary 테스트 데이터
+  // UserLibrary 테스트 데이터 (Paper를 참조하도록 변경)
   const mockUserLibraryEntities = [
     {
       id: 1,
       userId: 123,
-      paperContentId: 1,
+      paperId: 1, // paperContentId에서 paperId로 변경
       createdAt: new Date('2024-01-15'),
-      paperContent: Promise.resolve({
-        id: 1,
-        title: 'AI와 머신러닝의 발전',
-        authors: '김철수, 이영희',
-        content: '논문 전체 내용...',
-        paperId: 1,
-        createdAt: new Date('2024-01-15'),
-      }),
+      paper: Promise.resolve(mockPaperEntities[0]),
     },
     {
       id: 2,
       userId: 123,
-      paperContentId: 2,
-      createdAt: new Date('2024-01-20'),
-      paperContent: Promise.resolve({
-        id: 2,
-        title: '딥러닝을 활용한 자연어 처리',
-        authors: '박민수',
-        content: '논문 전체 내용...',
-        paperId: 2,
-        createdAt: new Date('2024-01-20'),
-      }),
-    },
-    {
-      id: 3,
-      userId: 123,
-      paperContentId: 3,
-      createdAt: new Date('2024-01-25'),
-      paperContent: Promise.resolve({
-        id: 3,
-        title: '컴퓨터 비전의 최신 동향',
-        authors: '최지영, 정현우, 김태호',
-        content: '논문 전체 내용...',
-        paperId: 3,
-        createdAt: new Date('2024-01-25'),
-      }),
-    },
-  ];
-
-  // PaperDetail 테스트 데이터
-  const mockPaperContentEntities = [
-    {
-      id: 1,
-      title: 'AI와 머신러닝의 발전',
-      authors: '김철수, 이영희',
-      content:
-        '이 논문은 인공지능과 머신러닝의 최신 발전 동향을 다룹니다. 특히 딥러닝 모델의 성능 향상과 실제 응용 사례에 대해 자세히 분석합니다.',
-      paperId: 1,
-      createdAt: new Date('2024-01-15'),
-      paper: {
-        id: 1,
-        title: 'AI와 머신러닝의 발전',
-        summary: '이 논문은 **AI**와 머신러닝의 최신 발전 동향을 다룹니다.',
-        abstract: '이 논문은 **AI**와 머신러닝의 최신 발전 동향을 다룹니다.',
-        authors: '["김철수", "이영희"]',
-        url: 'https://example.com/paper1',
-        updateDate: new Date('2024-01-15'),
-        createdAt: new Date('2024-01-15'),
-      },
-    },
-    {
-      id: 2,
-      title: '딥러닝을 활용한 자연어 처리',
-      authors: '박민수',
-      content:
-        '자연어 처리를 위한 딥러닝 모델의 성능 향상에 대한 연구입니다. Transformer 아키텍처와 BERT 모델의 발전 과정을 다룹니다.',
       paperId: 2,
       createdAt: new Date('2024-01-20'),
-      paper: {
-        id: 2,
-        title: '딥러닝을 활용한 자연어 처리',
-        summary: '자연어 처리를 위한 **딥러닝** 모델의 성능 향상에 대한 연구입니다.',
-        abstract: '자연어 처리를 위한 **딥러닝** 모델의 성능 향상에 대한 연구입니다.',
-        authors: '["박민수"]',
-        url: 'https://example.com/paper2',
-        updateDate: new Date('2024-01-20'),
-        createdAt: new Date('2024-01-20'),
-      },
+      paper: Promise.resolve(mockPaperEntities[1]),
     },
     {
       id: 3,
-      title: '컴퓨터 비전의 최신 동향',
-      authors: '최지영, 정현우, 김태호',
-      content:
-        '컴퓨터 비전 분야에서 CNN과 Vision Transformer의 발전 과정을 다룹니다. 이미지 분류, 객체 감지, 세그멘테이션 등의 태스크에서의 성능 비교를 포함합니다.',
+      userId: 123,
       paperId: 3,
       createdAt: new Date('2024-01-25'),
-      paper: {
-        id: 3,
-        title: '컴퓨터 비전의 최신 동향',
-        summary: '컴퓨터 비전 분야에서 **CNN**과 **Vision Transformer**의 발전 과정을 다룹니다.',
-        abstract: '컴퓨터 비전 분야에서 **CNN**과 **Vision Transformer**의 발전 과정을 다룹니다.',
-        authors: '["최지영", "정현우", "김태호"]',
-        url: 'https://example.com/paper3',
-        updateDate: new Date('2024-01-25'),
-        createdAt: new Date('2024-01-25'),
-      },
+      paper: Promise.resolve(mockPaperEntities[2]),
     },
   ];
 
@@ -370,7 +329,7 @@ describe('paperService', () => {
 
       // 첫 번째 논문 확인
       const firstPaper = result.papers[0];
-      expect(firstPaper.paperContentId).toBe(1);
+      expect(firstPaper.paperContentId).toBe(1); // paperId를 paperContentId로 반환
       expect(firstPaper.title).toBe('AI와 머신러닝의 발전');
       expect(firstPaper.authors).toEqual(['김철수', '이영희']);
       expect(firstPaper.createdAt).toBeInstanceOf(Date);
@@ -553,45 +512,64 @@ describe('paperService', () => {
   });
 
   describe('getPaperDetail', () => {
-    it('존재하는 논문 콘텐츠 ID로 상세 정보를 조회할 수 있어야 한다', async () => {
-      // Repository 모킹 설정 - 논문 콘텐츠 존재
-      mockPaperContentRepository.findOne.mockResolvedValue(mockPaperContentEntities[0]);
+    it('존재하는 논문 ID로 상세 정보를 조회할 수 있어야 한다', async () => {
+      // Repository 모킹 설정 - 논문 존재 (paperContents 관계 포함)
+      mockRepository.findOne.mockResolvedValue(mockPaperEntities[0]);
 
       const result = await getPaperDetail(1);
 
       expect(result).not.toBeNull();
-      expect(result?.paperContentId).toBe(1);
+      expect(result?.paperContentId).toBe(1); // paperId를 paperContentId로 반환
       expect(result?.title).toBe('AI와 머신러닝의 발전');
       expect(result?.authors).toEqual(['김철수', '이영희']);
-      expect(result?.content).toBe(
-        '이 논문은 인공지능과 머신러닝의 최신 발전 동향을 다룹니다. 특히 딥러닝 모델의 성능 향상과 실제 응용 사례에 대해 자세히 분석합니다.'
+      expect(Array.isArray(result?.content)).toBe(true);
+      expect(result?.content).toHaveLength(2);
+      expect(result?.content[0].id).toBe(1);
+      expect(result?.content[0].title).toBe('Content 0');
+      expect(result?.content[0].content).toBe(
+        '이 논문은 인공지능과 머신러닝의 최신 발전 동향을 다룹니다.'
       );
+      expect(result?.content[0].order).toBe(0);
       expect(result?.createdAt).toBeInstanceOf(Date);
       expect(result?.publishedAt).toBeInstanceOf(Date);
       expect(result?.url).toBe('https://example.com/paper1');
 
-      expect(mockPaperContentRepository.findOne).toHaveBeenCalledWith({
+      expect(mockRepository.findOne).toHaveBeenCalledWith({
         where: { id: 1 },
-        relations: ['paper'],
+        relations: {
+          paperContents: true,
+        },
+        order: {
+          paperContents: {
+            order: 'ASC',
+          },
+        },
       });
     });
 
-    it('존재하지 않는 논문 콘텐츠 ID로 조회 시 null을 반환해야 한다', async () => {
-      // Repository 모킹 설정 - 논문 콘텐츠 없음
-      mockPaperContentRepository.findOne.mockResolvedValue(null);
+    it('존재하지 않는 논문 ID로 조회 시 null을 반환해야 한다', async () => {
+      // Repository 모킹 설정 - 논문 없음
+      mockRepository.findOne.mockResolvedValue(null);
 
       const result = await getPaperDetail(999);
 
       expect(result).toBeNull();
-      expect(mockPaperContentRepository.findOne).toHaveBeenCalledWith({
+      expect(mockRepository.findOne).toHaveBeenCalledWith({
         where: { id: 999 },
-        relations: ['paper'],
+        relations: {
+          paperContents: true,
+        },
+        order: {
+          paperContents: {
+            order: 'ASC',
+          },
+        },
       });
     });
 
     it('authors 필드가 올바르게 파싱되어야 한다', async () => {
       // Repository 모킹 설정 - 여러 저자가 있는 논문
-      mockPaperContentRepository.findOne.mockResolvedValue(mockPaperContentEntities[2]);
+      mockRepository.findOne.mockResolvedValue(mockPaperEntities[2]);
 
       const result = await getPaperDetail(3);
 
@@ -600,11 +578,11 @@ describe('paperService', () => {
 
     it('authors 필드가 비어있는 경우 빈 배열을 반환해야 한다', async () => {
       // Repository 모킹 설정 - 저자 정보가 없는 논문
-      const paperContentWithoutAuthors = {
-        ...mockPaperContentEntities[0],
+      const paperWithoutAuthors = {
+        ...mockPaperEntities[0],
         authors: null,
       };
-      mockPaperContentRepository.findOne.mockResolvedValue(paperContentWithoutAuthors);
+      mockRepository.findOne.mockResolvedValue(paperWithoutAuthors);
 
       const result = await getPaperDetail(1);
 
@@ -613,18 +591,56 @@ describe('paperService', () => {
 
     it('url 필드가 null인 경우 빈 문자열을 반환해야 한다', async () => {
       // Repository 모킹 설정 - URL이 null인 논문
-      const paperContentWithNullUrl = {
-        ...mockPaperContentEntities[0],
-        paper: {
-          ...mockPaperContentEntities[0].paper,
-          url: null,
-        },
+      const paperWithNullUrl = {
+        ...mockPaperEntities[0],
+        url: null,
       };
-      mockPaperContentRepository.findOne.mockResolvedValue(paperContentWithNullUrl);
+      mockRepository.findOne.mockResolvedValue(paperWithNullUrl);
 
       const result = await getPaperDetail(1);
 
       expect(result?.url).toBe('');
+    });
+
+    it('PaperContent가 없는 경우 빈 배열을 반환해야 한다', async () => {
+      // Repository 모킹 설정 - PaperContent가 없는 논문
+      const paperWithoutContents = {
+        ...mockPaperEntities[0],
+        paperContents: Promise.resolve([]),
+      };
+      mockRepository.findOne.mockResolvedValue(paperWithoutContents);
+
+      const result = await getPaperDetail(1);
+
+      expect(result?.content).toEqual([]);
+    });
+
+    it('PaperContent가 order 순으로 정렬되어야 한다', async () => {
+      // Repository 모킹 설정 - 순서가 뒤바뀐 PaperContent (DB에서 정렬됨)
+      const paperWithReorderedContents = {
+        ...mockPaperEntities[0],
+        paperContents: Promise.resolve([
+          {
+            id: 1,
+            content: '이 논문은 인공지능과 머신러닝의 최신 발전 동향을 다룹니다.',
+            order: 0,
+            createdAt: new Date('2024-01-15'),
+          },
+          {
+            id: 2,
+            content: '특히 딥러닝 모델의 성능 향상과 실제 응용 사례에 대해 자세히 분석합니다.',
+            order: 1,
+            createdAt: new Date('2024-01-15'),
+          },
+        ]),
+      };
+      mockRepository.findOne.mockResolvedValue(paperWithReorderedContents);
+
+      const result = await getPaperDetail(1);
+
+      expect(result?.content).toHaveLength(2);
+      expect(result?.content[0].order).toBe(0);
+      expect(result?.content[1].order).toBe(1);
     });
   });
 });


### PR DESCRIPTION
1. Paper 구조 리팩터링
- PaperContent를 1:1 구조가 아닌 1:N구조로 하여 콘텐츠 블록(예: 초록, 실험 방식 등 당 1블록)당 하나의 엔티티가 저장되도록 설계, DB에서 조회시 `order` 필드로 정렬되어 제공
- PaperCategory를 별도 테이블로 이동(1정규화)
- PaperContent를 블럭단위로 나눔에 따라  scrollspy-navigation를 적용하여 더 쉬운 읽기 지원