### PR TITLE
feat: 내가 수동으로 추가한 Abstract 만 볼 수 있는 기능 추가

### DIFF
--- a/app/api/papers/route.ts
+++ b/app/api/papers/route.ts
@@ -12,9 +12,10 @@ export async function GET(request: NextRequest) {
     const categories = searchParams.get('categories') ?? undefined;
     const year = searchParams.get('year') ?? undefined;
     const sort = searchParams.get('sort') ?? undefined;
+    const userOnly = searchParams.get('userOnly') === 'true';
 
     // 논문 데이터 가져오기
-    const result = await getPapers(page, limit, search, categories, year, sort);
+    const result = await getPapers(page, limit, search, categories, year, sort, userOnly);
 
     return NextResponse.json(result);
   } catch (error) {

--- a/components/papers/PaperList.tsx
+++ b/components/papers/PaperList.tsx
@@ -39,6 +39,7 @@ export default function PaperList() {
   const categories = searchParams.get('categories');
   const publicationYear = searchParams.get('year');
   const sortBy = searchParams.get('sort');
+  const userOnly = searchParams.get('userOnly') === 'true';
 
   useEffect(() => {
     const fetchPapers = async () => {
@@ -56,6 +57,7 @@ export default function PaperList() {
         if (categories) params.append('categories', categories);
         if (publicationYear) params.append('year', publicationYear);
         if (sortBy) params.append('sort', sortBy);
+        if (userOnly) params.append('userOnly', 'true');
 
         const response = await fetch(`/api/papers?${params.toString()}`);
 
@@ -73,7 +75,7 @@ export default function PaperList() {
     };
 
     fetchPapers();
-  }, [currentPage, searchQuery, categories, publicationYear, sortBy]);
+  }, [currentPage, searchQuery, categories, publicationYear, sortBy, userOnly]);
 
   // 로딩 중일 때 스켈레톤 표시
   if (loading) {

--- a/components/papers/PaperSearch.tsx
+++ b/components/papers/PaperSearch.tsx
@@ -28,6 +28,7 @@ export default function PaperSearch({ categories = [] }: PaperSearchProps) {
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
   const [publicationYear, setPublicationYear] = useState(searchParams.get('year') || 'all');
   const [sortBy, setSortBy] = useState(searchParams.get('sort') || 'newest');
+  const [userOnly, setUserOnly] = useState(searchParams.get('userOnly') === 'true');
   const [showAdvancedSearch, setShowAdvancedSearch] = useState(false);
 
   const handleSearch = () => {
@@ -47,6 +48,10 @@ export default function PaperSearch({ categories = [] }: PaperSearchProps) {
 
     if (sortBy && sortBy !== 'newest') {
       params.set('sort', sortBy);
+    }
+
+    if (userOnly) {
+      params.set('userOnly', 'true');
     }
 
     // 페이지를 1로 리셋
@@ -69,6 +74,7 @@ export default function PaperSearch({ categories = [] }: PaperSearchProps) {
     setSelectedCategories([]);
     setPublicationYear('all');
     setSortBy('newest');
+    setUserOnly(false);
     router.push('/');
   };
 
@@ -90,6 +96,21 @@ export default function PaperSearch({ categories = [] }: PaperSearchProps) {
               onKeyDown={handleKeyPress}
               className="pl-10 pr-4 py-3 text-base"
             />
+          </div>
+
+          {/* 내가 추가한 논문만 보기 체크박스 */}
+          <div className="flex items-center space-x-2">
+            <Checkbox
+              id="userOnly"
+              checked={userOnly}
+              onCheckedChange={(checked: boolean) => setUserOnly(checked)}
+            />
+            <label
+              htmlFor="userOnly"
+              className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+            >
+              내가 추가한 논문만 보기
+            </label>
           </div>
 
           {/* 검색 버튼들 */}

--- a/lib/database/entities/UserPaperAbstracts.ts
+++ b/lib/database/entities/UserPaperAbstracts.ts
@@ -1,0 +1,45 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+/**
+ * 사용자 논문 초록 매핑 인터페이스
+ */
+export interface IUserPaperAbstracts extends Document {
+  /** 사용자 ID */
+  user_id: mongoose.Types.ObjectId;
+  /** 논문 ID */
+  paper_id: mongoose.Types.ObjectId;
+  /** 생성일 */
+  createdAt: Date;
+  /** 수정일 */
+  updatedAt: Date;
+}
+
+/**
+ * 사용자 논문 초록 매핑 스키마
+ */
+const UserPaperAbstractsSchema = new Schema<IUserPaperAbstracts>(
+  {
+    user_id: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    paper_id: {
+      type: Schema.Types.ObjectId,
+      ref: 'Paper',
+      required: true,
+      index: true,
+    },
+  },
+  {
+    timestamps: true,
+    collection: 'user_paper_abstracts',
+  }
+);
+
+// 복합 인덱스 (user_id, paper_id)
+UserPaperAbstractsSchema.index({ user_id: 1, paper_id: 1 }, { unique: true });
+
+export const UserPaperAbstracts = mongoose.models.UserPaperAbstracts || 
+  mongoose.model<IUserPaperAbstracts>('UserPaperAbstracts', UserPaperAbstractsSchema);

--- a/lib/database/entities/index.ts
+++ b/lib/database/entities/index.ts
@@ -6,6 +6,7 @@ export { RSSUrl, type IRSSUrl } from './RSSUrl';
 export { RSSFeed, type IRSSFeed } from './RSSFeed';
 export { UserLibrary, type IUserLibrary } from './UserLibrary';
 export { UserInterests, type IUserInterests } from './UserInterests';
+export { UserPaperAbstracts, type IUserPaperAbstracts } from './UserPaperAbstracts';
 
 // 모든 모델을 배열로 export (초기화 시 사용)
 export const models = [
@@ -16,4 +17,5 @@ export const models = [
   'RSSFeed',
   'UserLibrary',
   'UserInterests',
+  'UserPaperAbstracts',
 ] as const;


### PR DESCRIPTION
- Paper 리스트 필터 섹션에 "내가 추가한 논문만 보기" 체크박스 추가
- 체크 박스를 누르고 "검색"버튼 클릭시, 파라미터에 userOnly=true가 searchparam으로 붙음.
- PaperList 컴포넌트는 userOnly searchParam을 인식해, API를 보낼때 이 파라미터를 전달해줌.
- API는 user_paper_abstracts 컬렉션에 먼저 user_id가 가진 paper_id를 모두 검색해오고, 이를 검색 쿼리에 _id in 쿼리를 사용해 검색